### PR TITLE
Prevent preset data overwrite on mount

### DIFF
--- a/src/components/multisample/MultisamplePresetSettings.tsx
+++ b/src/components/multisample/MultisamplePresetSettings.tsx
@@ -136,11 +136,6 @@ export function MultisamplePresetSettings() {
     state.multisampleSettings.filterEnvelope,
   ]);
 
-  // Dispatch initial settings to app context on mount
-  useEffect(() => {
-    dispatchSettingsToContext(settings);
-  }, []); // Only run once on mount
-
   const noteNames = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
 
   const handleImportClick = () => {


### PR DESCRIPTION
Remove unnecessary `useEffect` dispatching initial settings to prevent data loss.

The `useEffect` hook, intended to run once on mount, dispatched the component's `settings` to the global context. Since these `settings` were initialized from the global `multisampleSettings` state, this initial dispatch unnecessarily overwrote the `importedMultisamplePreset` in the global state. This led to data loss, as any previously loaded preset data (e.g., from session restoration or file import) was replaced with values derived from the current `multisampleSettings`, which might be defaults. The settings are already synchronized with the global state through another `useEffect` that watches for changes in `state.multisampleSettings`.