### PR TITLE
Add "organize mode". Remove protections against FP32 samples. 

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "printWidth": 120,
+  "arrowParens": "always"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "globals": "^16.2.0",
         "jest": "^30.0.3",
         "jsdom": "^25.0.1",
+        "prettier": "^3.6.2",
         "semver": "^7.7.2",
         "sharp": "^0.34.2",
         "typescript": "~5.8.3",
@@ -11086,6 +11087,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-bytes": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "op-patchstudio",
-  "version": "0.15.5",
+  "version": "0.14.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "op-patchstudio",
-      "version": "0.15.5",
+      "version": "0.14.7",
       "license": "MIT",
       "dependencies": {
         "@carbon/react": "^1.85.1",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "globals": "^16.2.0",
     "jest": "^30.0.3",
     "jsdom": "^25.0.1",
+    "prettier": "^3.6.2",
     "semver": "^7.7.2",
     "sharp": "^0.34.2",
     "typescript": "~5.8.3",

--- a/src/components/drum/DrumKeyboard.tsx
+++ b/src/components/drum/DrumKeyboard.tsx
@@ -193,13 +193,10 @@ export function DrumKeyboard({
   const totalGaps = gap * (numKeys - 1); // 6 gaps between 7 keys
   // Use full viewport width for calculation
   const availableWidth = containerWidth;
-  const keyWidth =
-    isMobile && containerWidth > 0 ? Math.floor((availableWidth - totalGaps) / numKeys) : 56;
+  const keyWidth = isMobile && containerWidth > 0 ? Math.floor((availableWidth - totalGaps) / numKeys) : 56;
 
   // Check if MIDI is connected (initialized and has input devices)
-  const inputDevices = midiState.devices.filter(
-    (device) => device.type === 'input' && device.state === 'connected'
-  );
+  const inputDevices = midiState.devices.filter((device) => device.type === 'input' && device.state === 'connected');
   const isMidiConnected = midiState.isInitialized && inputDevices.length > 0;
 
   const playSample = async (index: number) => {
@@ -209,10 +206,7 @@ export function DrumKeyboard({
     }
     try {
       await play(sample.audioBuffer, {
-        inFrame:
-          sample.inPoint !== undefined
-            ? Math.floor(sample.inPoint * sample.audioBuffer.sampleRate)
-            : 0,
+        inFrame: sample.inPoint !== undefined ? Math.floor(sample.inPoint * sample.audioBuffer.sampleRate) : 0,
         outFrame:
           sample.outPoint !== undefined
             ? Math.floor(sample.outPoint * sample.audioBuffer.sampleRate)
@@ -439,14 +433,7 @@ export function DrumKeyboard({
     } else if (!selectedMidiChannel) {
       // No MIDI channel selected
     }
-  }, [
-    isMidiConnected,
-    selectedMidiChannel,
-    onMidiEvent,
-    handleMidiEvent,
-    midiState.devices,
-    state.currentTab,
-  ]);
+  }, [isMidiConnected, selectedMidiChannel, onMidiEvent, handleMidiEvent, midiState.devices, state.currentTab]);
 
   // Helper functions to create common OPXYKey props
   const createKeyProps = (
@@ -477,8 +464,7 @@ export function DrumKeyboard({
     };
   };
 
-  const createStandardKeyProps = (keyChar: string, octave: number) =>
-    createKeyProps(keyChar, octave, false, 'center');
+  const createStandardKeyProps = (keyChar: string, octave: number) => createKeyProps(keyChar, octave, false, 'center');
 
   const createLargeKeyProps = (keyChar: string, octave: number, circleOffset: 'left' | 'right') =>
     createKeyProps(keyChar, octave, true, circleOffset);
@@ -528,9 +514,7 @@ export function DrumKeyboard({
 
     // Use keyWidth for all proportional sizing
     const baseSize = keyWidth;
-    const width = isLarge
-      ? baseSize * 1.5 + (keyChar === 'W' || keyChar === 'U' ? 1 : 0)
-      : baseSize;
+    const width = isLarge ? baseSize * 1.5 + (keyChar === 'W' || keyChar === 'U' ? 1 : 0) : baseSize;
     const height = baseSize;
     const circleSize = baseSize * (35 / 56);
     const outerRingSize = baseSize * (52 / 56); // Scale outer ring too
@@ -678,9 +662,7 @@ export function DrumKeyboard({
             e.currentTarget.style.boxShadow = isActive
               ? '0 4px 12px rgba(0, 0, 0, 0.18)'
               : '0 2px 6px rgba(0, 0, 0, 0.1)';
-            e.currentTarget.style.borderColor = !isActive
-              ? 'var(--color-key-inactive-border)'
-              : 'var(--color-black)';
+            e.currentTarget.style.borderColor = !isActive ? 'var(--color-key-inactive-border)' : 'var(--color-black)';
           }}
           onDrop={(e) => {
             e.preventDefault();
@@ -696,9 +678,7 @@ export function DrumKeyboard({
             e.currentTarget.style.boxShadow = isActive
               ? '0 4px 12px rgba(0, 0, 0, 0.18)'
               : '0 2px 6px rgba(0, 0, 0, 0.1)';
-            e.currentTarget.style.borderColor = !isActive
-              ? 'var(--color-key-inactive-border)'
-              : 'var(--color-black)';
+            e.currentTarget.style.borderColor = !isActive ? 'var(--color-key-inactive-border)' : 'var(--color-black)';
 
             const files = Array.from(e.dataTransfer.files);
             const audioFile = files.find(
@@ -747,9 +727,7 @@ export function DrumKeyboard({
               width: `${outerRingSize}px`,
               height: `${outerRingSize}px`,
               background: 'transparent',
-              border: !isActive
-                ? '1px solid var(--color-key-inactive-border)'
-                : '1px solid var(--color-black)',
+              border: !isActive ? '1px solid var(--color-key-inactive-border)' : '1px solid var(--color-black)',
               marginLeft: circleStyle.marginLeft === '0' ? '0' : `-${outerRingSize / 2}px`, // Conditional centering
             }}
           >
@@ -827,9 +805,7 @@ export function DrumKeyboard({
             >
               <div
                 style={{
-                  backgroundColor: isWhiteKey
-                    ? 'rgba(76, 175, 80, 0.85)'
-                    : 'rgba(255, 152, 0, 0.85)',
+                  backgroundColor: isWhiteKey ? 'rgba(76, 175, 80, 0.85)' : 'rgba(255, 152, 0, 0.85)',
                   color: '#fff',
                   fontSize: `${baseSize * (7 / 56)}px`,
                   fontWeight: '700',
@@ -974,11 +950,7 @@ export function DrumKeyboard({
                 }}
               >
                 {/* Octave 0 Panel */}
-                <div
-                  role="group"
-                  aria-label="Lower octave drum keys"
-                  style={{ width: '50%', flexShrink: 0 }}
-                >
+                <div role="group" aria-label="Lower octave drum keys" style={{ width: '50%', flexShrink: 0 }}>
                   <div
                     style={{
                       display: 'flex',
@@ -998,21 +970,14 @@ export function DrumKeyboard({
                     {/* Bottom row */}
                     <div style={{ display: 'flex', gap: '1px' }}>
                       {['A', 'S', 'D', 'F', 'G', 'H', 'J'].map((key) => (
-                        <OPXYKey
-                          key={`octave0-mobile-${key}`}
-                          {...createStandardKeyProps(key, 0)}
-                        />
+                        <OPXYKey key={`octave0-mobile-${key}`} {...createStandardKeyProps(key, 0)} />
                       ))}
                     </div>
                   </div>
                 </div>
 
                 {/* Octave 1 Panel */}
-                <div
-                  role="group"
-                  aria-label="Upper octave drum keys"
-                  style={{ width: '50%', flexShrink: 0 }}
-                >
+                <div role="group" aria-label="Upper octave drum keys" style={{ width: '50%', flexShrink: 0 }}>
                   <div
                     style={{
                       display: 'flex',
@@ -1032,10 +997,7 @@ export function DrumKeyboard({
                     {/* Bottom row */}
                     <div style={{ display: 'flex', gap: '1px' }}>
                       {['A', 'S', 'D', 'F', 'G', 'H', 'J'].map((key) => (
-                        <OPXYKey
-                          key={`octave1-mobile-${key}`}
-                          {...createStandardKeyProps(key, 1)}
-                        />
+                        <OPXYKey key={`octave1-mobile-${key}`} {...createStandardKeyProps(key, 1)} />
                       ))}
                     </div>
                   </div>
@@ -1061,8 +1023,7 @@ export function DrumKeyboard({
                 width: '8px',
                 height: '8px',
                 borderRadius: '50%',
-                background:
-                  currentOctave === 0 ? 'var(--color-text-secondary)' : 'var(--color-border-light)',
+                background: currentOctave === 0 ? 'var(--color-text-secondary)' : 'var(--color-border-light)',
                 transition: 'background-color 0.3s ease',
                 margin: '0 4px',
               }}
@@ -1072,8 +1033,7 @@ export function DrumKeyboard({
                 width: '8px',
                 height: '8px',
                 borderRadius: '50%',
-                background:
-                  currentOctave === 1 ? 'var(--color-text-secondary)' : 'var(--color-border-light)',
+                background: currentOctave === 1 ? 'var(--color-text-secondary)' : 'var(--color-border-light)',
                 transition: 'background-color 0.3s ease',
                 margin: '0 4px',
               }}

--- a/src/components/drum/DrumKeyboard.tsx
+++ b/src/components/drum/DrumKeyboard.tsx
@@ -6,42 +6,41 @@ import type { MidiEvent } from '../../utils/midi';
 import type { WebMidiState, WebMidiHookReturn } from '../../hooks/useWebMidi';
 import { UI_CONSTANTS } from '../../utils/constants';
 
-
 // Drum key mapping for two octaves (matching legacy)
 const drumKeyMap = [
   // Lower octave (octave 0)
   {
     // top row (offset like a real keyboard)
-    W: { label: "KD2", idx: 1 }, // index 1 = sample 2
-    E: { label: "SD2", idx: 3 }, // index 3 = sample 4
-    R: { label: "CLP", idx: 5 }, // index 5 = sample 6
-    Y: { label: "CH", idx: 8 },  // index 8 = sample 9
-    U: { label: "OH", idx: 10 }, // index 10 = sample 11
+    W: { label: 'KD2', idx: 1 }, // index 1 = sample 2
+    E: { label: 'SD2', idx: 3 }, // index 3 = sample 4
+    R: { label: 'CLP', idx: 5 }, // index 5 = sample 6
+    Y: { label: 'CH', idx: 8 }, // index 8 = sample 9
+    U: { label: 'OH', idx: 10 }, // index 10 = sample 11
     // bottom row
-    A: { label: "KD1", idx: 0 },  // index 0 = sample 1
-    S: { label: "SD1", idx: 2 },  // index 2 = sample 3
-    D: { label: "RIM", idx: 4 },  // index 4 = sample 5
-    F: { label: "TB", idx: 6 },   // index 6 = sample 7
-    G: { label: "SH", idx: 7 },   // index 7 = sample 8
-    H: { label: "CL", idx: 9 },   // index 9 = sample 10
-    J: { label: "CAB", idx: 11 }, // index 11 = sample 12
+    A: { label: 'KD1', idx: 0 }, // index 0 = sample 1
+    S: { label: 'SD1', idx: 2 }, // index 2 = sample 3
+    D: { label: 'RIM', idx: 4 }, // index 4 = sample 5
+    F: { label: 'TB', idx: 6 }, // index 6 = sample 7
+    G: { label: 'SH', idx: 7 }, // index 7 = sample 8
+    H: { label: 'CL', idx: 9 }, // index 9 = sample 10
+    J: { label: 'CAB', idx: 11 }, // index 11 = sample 12
   },
   // Upper octave (octave 1)
   {
     // top row (offset like a real keyboard)
-    W: { label: "RC", idx: 13 },  // index 13 = ride cymbal
-    E: { label: "CC", idx: 15 },  // index 15 = crash cymbal
-    R: { label: "COW", idx: 17 }, // index 17 = cowbell
-    Y: { label: "LC", idx: 20 },  // index 20 = low conga
-    U: { label: "HC", idx: 22 },  // index 22 = hi-conga
+    W: { label: 'RC', idx: 13 }, // index 13 = ride cymbal
+    E: { label: 'CC', idx: 15 }, // index 15 = crash cymbal
+    R: { label: 'COW', idx: 17 }, // index 17 = cowbell
+    Y: { label: 'LC', idx: 20 }, // index 20 = low conga
+    U: { label: 'HC', idx: 22 }, // index 22 = hi-conga
     // bottom row
-    A: { label: "LT1", idx: 12 },  // index 12 = low tom
-    S: { label: "MT", idx: 14 },  // index 14 = mid-tom
-    D: { label: "HT", idx: 16 },  // index 16 = hi-tom
-    F: { label: "TRI", idx: 18 }, // index 18 = triangle
-    G: { label: "LT2", idx: 19 },  // index 19 = low tom alt
-    H: { label: "WS", idx: 21 },  // index 21 = wood stick
-    J: { label: "GUI", idx: 23 }, // index 23 = guiro
+    A: { label: 'LT1', idx: 12 }, // index 12 = low tom
+    S: { label: 'MT', idx: 14 }, // index 14 = mid-tom
+    D: { label: 'HT', idx: 16 }, // index 16 = hi-tom
+    F: { label: 'TRI', idx: 18 }, // index 18 = triangle
+    G: { label: 'LT2', idx: 19 }, // index 19 = low tom alt
+    H: { label: 'WS', idx: 21 }, // index 21 = wood stick
+    J: { label: 'GUI', idx: 23 }, // index 23 = guiro
   },
 ];
 
@@ -50,9 +49,16 @@ interface DrumKeyboardProps {
   selectedMidiChannel?: number;
   midiState?: WebMidiState;
   onMidiEventExternal?: WebMidiHookReturn['onMidiEvent'];
+  isOrganizeMode?: boolean;
 }
 
-export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: externalMidiState, onMidiEventExternal }: DrumKeyboardProps = {}) {
+export function DrumKeyboard({
+  onFileUpload,
+  selectedMidiChannel,
+  midiState: externalMidiState,
+  onMidiEventExternal,
+  isOrganizeMode = false,
+}: DrumKeyboardProps = {}) {
   const { state } = useAppContext();
   const [currentOctave, setCurrentOctave] = useState(0);
   const [pressedKeys, setPressedKeys] = useState<Set<string>>(new Set()); // Format: "keyChar:octave" e.g., "A:0", "W:1"
@@ -65,7 +71,7 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
   const internalWebMidi = useWebMidi();
   const onMidiEvent = onMidiEventExternal ?? internalWebMidi.onMidiEvent;
   const midiState = externalMidiState ?? internalWebMidi.state;
-  
+
   // Touch/swipe handling for mobile
   const touchStartX = useRef<number | null>(null);
   const touchEndX = useRef<number | null>(null);
@@ -100,7 +106,7 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
 
   const handleTouchEnd = (e: React.TouchEvent) => {
     if (!touchStartX.current || !touchEndX.current) return;
-    
+
     const distance = Math.abs(touchStartX.current - touchEndX.current);
 
     // It's a swipe
@@ -111,21 +117,21 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
       } else if (!isLeftSwipe && currentOctave === 1) {
         setCurrentOctave(0);
       }
-    } 
+    }
     // It's a tap
     else {
       const touch = e.changedTouches[0];
       const targetElement = document.elementFromPoint(touch.clientX, touch.clientY);
       const keyButton = targetElement?.closest('button[data-keychar]');
-      
+
       if (keyButton) {
         const keyChar = keyButton.getAttribute('data-keychar');
         const octaveStr = keyButton.getAttribute('data-octave');
-        
+
         if (keyChar && octaveStr) {
           const octave = parseInt(octaveStr, 10);
-          const mapping = drumKeyMap[octave]?.[keyChar as keyof typeof drumKeyMap[0]];
-          
+          const mapping = drumKeyMap[octave]?.[keyChar as keyof (typeof drumKeyMap)[0]];
+
           if (mapping) {
             const hasContent = state.drumSamples[mapping.idx]?.isLoaded;
             if (hasContent) {
@@ -136,9 +142,9 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
 
             // brief visual feedback for the tap
             const keyIdentifier = `${keyChar}:${octave}`;
-            setPressedKeys(prev => new Set(prev).add(keyIdentifier));
+            setPressedKeys((prev) => new Set(prev).add(keyIdentifier));
             setTimeout(() => {
-              setPressedKeys(prev => {
+              setPressedKeys((prev) => {
                 const newSet = new Set(prev);
                 newSet.delete(keyIdentifier);
                 return newSet;
@@ -187,10 +193,13 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
   const totalGaps = gap * (numKeys - 1); // 6 gaps between 7 keys
   // Use full viewport width for calculation
   const availableWidth = containerWidth;
-  const keyWidth = isMobile && containerWidth > 0 ? Math.floor((availableWidth - totalGaps) / numKeys) : 56;
+  const keyWidth =
+    isMobile && containerWidth > 0 ? Math.floor((availableWidth - totalGaps) / numKeys) : 56;
 
   // Check if MIDI is connected (initialized and has input devices)
-  const inputDevices = midiState.devices.filter(device => device.type === 'input' && device.state === 'connected');
+  const inputDevices = midiState.devices.filter(
+    (device) => device.type === 'input' && device.state === 'connected'
+  );
   const isMidiConnected = midiState.isInitialized && inputDevices.length > 0;
 
   const playSample = async (index: number) => {
@@ -200,8 +209,14 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
     }
     try {
       await play(sample.audioBuffer, {
-        inFrame: sample.inPoint !== undefined ? Math.floor(sample.inPoint * sample.audioBuffer.sampleRate) : 0,
-        outFrame: sample.outPoint !== undefined ? Math.floor(sample.outPoint * sample.audioBuffer.sampleRate) : sample.audioBuffer.length,
+        inFrame:
+          sample.inPoint !== undefined
+            ? Math.floor(sample.inPoint * sample.audioBuffer.sampleRate)
+            : 0,
+        outFrame:
+          sample.outPoint !== undefined
+            ? Math.floor(sample.outPoint * sample.audioBuffer.sampleRate)
+            : sample.audioBuffer.length,
         playbackRate: Math.pow(2, (sample.transpose || 0) / 12),
         gain: sample.gain || 0,
         pan: sample.pan || 0,
@@ -213,7 +228,7 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
   };
 
   const getDrumIdxForKey = (key: string) => {
-    const mapping = drumKeyMap[currentOctave][key as keyof typeof drumKeyMap[0]];
+    const mapping = drumKeyMap[currentOctave][key as keyof (typeof drumKeyMap)[0]];
     return mapping ? mapping.idx : null;
   };
 
@@ -238,16 +253,16 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
     const handleKeyDown = (e: KeyboardEvent) => {
       // Check if user is typing in an input field
       const activeElement = document.activeElement;
-      const isTyping = activeElement && (
-        activeElement.tagName === 'INPUT' ||
-        activeElement.tagName === 'TEXTAREA' ||
-        (activeElement as HTMLElement).contentEditable === 'true'
-      );
-      
+      const isTyping =
+        activeElement &&
+        (activeElement.tagName === 'INPUT' ||
+          activeElement.tagName === 'TEXTAREA' ||
+          (activeElement as HTMLElement).contentEditable === 'true');
+
       if (isTyping) return;
 
       const key = e.key.toUpperCase();
-      
+
       // Handle octave switching
       if (key === 'Z') {
         setCurrentOctave(0);
@@ -262,13 +277,13 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
       const idx = getDrumIdxForKey(key);
       if (idx !== null && state.drumSamples[idx]) {
         playSample(idx);
-        setPressedKeys(prev => new Set(prev).add(`${key}:${currentOctave}`));
+        setPressedKeys((prev) => new Set(prev).add(`${key}:${currentOctave}`));
       }
     };
 
     const handleKeyUp = (e: KeyboardEvent) => {
       const key = e.key.toUpperCase();
-      setPressedKeys(prev => {
+      setPressedKeys((prev) => {
         const newSet = new Set(prev);
         // Remove the key from both octaves since we don't know which one was pressed
         newSet.delete(`${key}:0`);
@@ -287,66 +302,68 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
   }, [currentOctave, state.drumSamples]);
 
   // MIDI event handling
-  const handleMidiEvent = useCallback((event: MidiEvent) => {
-    if (event.type === 'noteon' && event.velocity > 0) {
-      const note = event.note;
+  const handleMidiEvent = useCallback(
+    (event: MidiEvent) => {
+      if (event.type === 'noteon' && event.velocity > 0) {
+        const note = event.note;
 
-      
-      // Map MIDI note to drum sample index
-      const drumIndex = getDrumIndexFromMidiNote(note);
-      if (drumIndex !== null) {
-        // Determine which octave this note belongs to and switch if needed
-        const isUpperOctave = drumIndex >= 12;
-        if (isUpperOctave && currentOctave !== 1) {
-          setCurrentOctave(1);
-        } else if (!isUpperOctave && currentOctave !== 0) {
-          setCurrentOctave(0);
+        // Map MIDI note to drum sample index
+        const drumIndex = getDrumIndexFromMidiNote(note);
+        if (drumIndex !== null) {
+          // Determine which octave this note belongs to and switch if needed
+          const isUpperOctave = drumIndex >= 12;
+          if (isUpperOctave && currentOctave !== 1) {
+            setCurrentOctave(1);
+          } else if (!isUpperOctave && currentOctave !== 0) {
+            setCurrentOctave(0);
+          }
+          playSample(drumIndex);
+          // Add visual feedback by finding the key character and octave
+          const keyChar = getKeyCharFromDrumIndex(drumIndex);
+          if (keyChar) {
+            const keyOctave = isUpperOctave ? 1 : 0;
+            setPressedKeys((prev) => new Set([...prev, `${keyChar}:${keyOctave}`]));
+          }
+        } else {
+          // No drum mapping found for note
         }
-        playSample(drumIndex);
-        // Add visual feedback by finding the key character and octave
-        const keyChar = getKeyCharFromDrumIndex(drumIndex);
-        if (keyChar) {
-          const keyOctave = isUpperOctave ? 1 : 0;
-          setPressedKeys(prev => new Set([...prev, `${keyChar}:${keyOctave}`]));
+      } else if (event.type === 'noteoff') {
+        const note = event.note;
+        const drumIndex = getDrumIndexFromMidiNote(note);
+        if (drumIndex !== null) {
+          const keyChar = getKeyCharFromDrumIndex(drumIndex);
+          if (keyChar) {
+            const keyOctave = drumIndex >= 12 ? 1 : 0;
+            setPressedKeys((prev) => {
+              const newSet = new Set(prev);
+              newSet.delete(`${keyChar}:${keyOctave}`);
+              return newSet;
+            });
+          }
         }
-      } else {
-        // No drum mapping found for note
       }
-    } else if (event.type === 'noteoff') {
-      const note = event.note;
-      const drumIndex = getDrumIndexFromMidiNote(note);
-      if (drumIndex !== null) {
-        const keyChar = getKeyCharFromDrumIndex(drumIndex);
-        if (keyChar) {
-          const keyOctave = drumIndex >= 12 ? 1 : 0;
-          setPressedKeys(prev => {
-            const newSet = new Set(prev);
-            newSet.delete(`${keyChar}:${keyOctave}`);
-            return newSet;
-          });
-        }
-      }
-    }
-  }, [playSample, currentOctave]);
+    },
+    [playSample, currentOctave]
+  );
 
   // Helper function to map MIDI note to drum index
   const getDrumIndexFromMidiNote = (note: number): number | null => {
     // Lower octave (octave 0) - F3 to F4
     const lowerOctaveMap: { [key: number]: number } = {
-      53: 0,  // F3  -> KD1 (A key)
-      54: 1,  // F#3 -> KD2 (W key) 
-      55: 2,  // G3  -> SD1 (S key)
-      56: 3,  // G#3 -> SD2 (E key)
-      57: 4,  // A3  -> RIM (D key)
-      58: 5,  // A#3 -> CLP (R key)
-      59: 6,  // B3  -> TB (F key)
-      60: 7,  // C4  -> SH (G key) - Middle C
-      61: 8,  // C#4 -> CH (Y key)
-      62: 9,  // D4  -> CL (H key)
+      53: 0, // F3  -> KD1 (A key)
+      54: 1, // F#3 -> KD2 (W key)
+      55: 2, // G3  -> SD1 (S key)
+      56: 3, // G#3 -> SD2 (E key)
+      57: 4, // A3  -> RIM (D key)
+      58: 5, // A#3 -> CLP (R key)
+      59: 6, // B3  -> TB (F key)
+      60: 7, // C4  -> SH (G key) - Middle C
+      61: 8, // C#4 -> CH (Y key)
+      62: 9, // D4  -> CL (H key)
       63: 10, // D#4 -> OH (U key)
       64: 11, // E4  -> CAB (J key)
     };
-    
+
     // Upper octave (octave 1) - F4 to E5
     const upperOctaveMap: { [key: number]: number } = {
       65: 12, // F4  -> LT1 (A key, octave 1)
@@ -362,7 +379,7 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
       75: 22, // D#5 -> HC (U key, octave 1)
       76: 23, // E5  -> GUI (J key, octave 1)
     };
-    
+
     return lowerOctaveMap[note] ?? upperOctaveMap[note] ?? null;
   };
 
@@ -370,36 +387,36 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
   const getKeyCharFromDrumIndex = (drumIndex: number): string | null => {
     // Lower octave (octave 0)
     const lowerOctaveKeys: { [key: number]: string } = {
-      0: 'A',   // KD1
-      1: 'W',   // KD2
-      2: 'S',   // SD1
-      3: 'E',   // SD2
-      4: 'D',   // RIM
-      5: 'R',   // CLP
-      6: 'F',   // TB
-      7: 'G',   // SH
-      8: 'Y',   // CH
-      9: 'H',   // CL
-      10: 'U',  // OH
-      11: 'J',  // CAB
+      0: 'A', // KD1
+      1: 'W', // KD2
+      2: 'S', // SD1
+      3: 'E', // SD2
+      4: 'D', // RIM
+      5: 'R', // CLP
+      6: 'F', // TB
+      7: 'G', // SH
+      8: 'Y', // CH
+      9: 'H', // CL
+      10: 'U', // OH
+      11: 'J', // CAB
     };
-    
+
     // Upper octave (octave 1)
     const upperOctaveKeys: { [key: number]: string } = {
-      12: 'A',  // LT
-      13: 'W',  // RC
-      14: 'S',  // MT
-      15: 'E',  // CC
-      16: 'D',  // HT
-      17: 'R',  // COW
-      18: 'F',  // TRI
-      19: 'G',  // LT2
-      20: 'Y',  // LC
-      21: 'H',  // WS
-      22: 'U',  // HC
-      23: 'J',  // GUI
+      12: 'A', // LT
+      13: 'W', // RC
+      14: 'S', // MT
+      15: 'E', // CC
+      16: 'D', // HT
+      17: 'R', // COW
+      18: 'F', // TRI
+      19: 'G', // LT2
+      20: 'Y', // LC
+      21: 'H', // WS
+      22: 'U', // HC
+      23: 'J', // GUI
     };
-    
+
     return lowerOctaveKeys[drumIndex] ?? upperOctaveKeys[drumIndex] ?? null;
   };
 
@@ -412,7 +429,7 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
 
     if (isMidiConnected && selectedMidiChannel) {
       const cleanup = onMidiEvent(handleMidiEvent, selectedMidiChannel); // Listen on selected channel only
-      
+
       // Cleanup function
       return () => {
         cleanup();
@@ -422,11 +439,27 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
     } else if (!selectedMidiChannel) {
       // No MIDI channel selected
     }
-  }, [isMidiConnected, selectedMidiChannel, onMidiEvent, handleMidiEvent, midiState.devices, state.currentTab]);
+  }, [
+    isMidiConnected,
+    selectedMidiChannel,
+    onMidiEvent,
+    handleMidiEvent,
+    midiState.devices,
+    state.currentTab,
+  ]);
 
   // Helper functions to create common OPXYKey props
-  const createKeyProps = (keyChar: string, octave: number, isLarge = false, circleOffset: 'left' | 'right' | 'center' = 'center') => {
-    const mapping = drumKeyMap[octave][keyChar as keyof typeof drumKeyMap[0]];
+  const createKeyProps = (
+    keyChar: string,
+    octave: number,
+    isLarge = false,
+    circleOffset: 'left' | 'right' | 'center' = 'center'
+  ) => {
+    const mapping = drumKeyMap[octave][keyChar as keyof (typeof drumKeyMap)[0]];
+    // Determine if this is a white key (bottom row) or black key (top row)
+    const isWhiteKey = ['A', 'S', 'D', 'F', 'G', 'H', 'J'].includes(keyChar);
+    const isBlackKey = ['W', 'E', 'R', 'Y', 'U'].includes(keyChar);
+
     return {
       keyChar,
       mapping,
@@ -437,31 +470,37 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
       isActiveOctave: currentOctave === octave,
       showKeyboardLabels: currentOctave === octave && !isMidiConnected,
       isMobile,
-      keyWidth
+      keyWidth,
+      isOrganizeMode,
+      isWhiteKey,
+      isBlackKey,
     };
   };
 
-  const createStandardKeyProps = (keyChar: string, octave: number) => 
+  const createStandardKeyProps = (keyChar: string, octave: number) =>
     createKeyProps(keyChar, octave, false, 'center');
 
-  const createLargeKeyProps = (keyChar: string, octave: number, circleOffset: 'left' | 'right') => 
+  const createLargeKeyProps = (keyChar: string, octave: number, circleOffset: 'left' | 'right') =>
     createKeyProps(keyChar, octave, true, circleOffset);
 
   // OP-XY key component with exact 1:1 and 1:1.5 ratios
-  const OPXYKey = ({ 
-    keyChar, 
-    mapping, 
+  const OPXYKey = ({
+    keyChar,
+    mapping,
     octave, // Add octave to the props
-    isPressed, 
+    isPressed,
     isLarge = false,
     circleOffset = 'center', // 'left', 'right', or 'center'
     isActiveOctave = true,
     showKeyboardLabels = true,
     isMobile = false,
-    keyWidth = 56
-  }: { 
-    keyChar: string; 
-    mapping?: { label: string; idx: number }; 
+    keyWidth = 56,
+    isOrganizeMode = false,
+    isWhiteKey = false,
+    isBlackKey = false,
+  }: {
+    keyChar: string;
+    mapping?: { label: string; idx: number };
     octave: number; // Add octave to the type
     isPressed: boolean;
     isLarge?: boolean;
@@ -470,10 +509,13 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
     showKeyboardLabels?: boolean;
     isMobile?: boolean;
     keyWidth?: number;
+    isOrganizeMode?: boolean;
+    isWhiteKey?: boolean;
+    isBlackKey?: boolean;
   }) => {
     const hasContent = mapping && state.drumSamples[mapping.idx]?.isLoaded;
     const isActive = hasContent; // Key is only active when it has content
-    
+
     // This function contains the core action for the key
     const handleActivate = () => {
       if (!mapping) return;
@@ -486,17 +528,23 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
 
     // Use keyWidth for all proportional sizing
     const baseSize = keyWidth;
-    const width = isLarge ? baseSize * 1.5 + (keyChar === 'W' || keyChar === 'U' ? 1 : 0) : baseSize;
+    const width = isLarge
+      ? baseSize * 1.5 + (keyChar === 'W' || keyChar === 'U' ? 1 : 0)
+      : baseSize;
     const height = baseSize;
-    const circleSize = baseSize * (35/56);
-    const outerRingSize = baseSize * (52/56); // Scale outer ring too
-    
+    const circleSize = baseSize * (35 / 56);
+    const outerRingSize = baseSize * (52 / 56); // Scale outer ring too
+
     let circleStyle: React.CSSProperties = {
       position: 'absolute',
       width: `${circleSize}px`,
       height: `${circleSize}px`,
       borderRadius: '50%',
-      background: !isActive ? 'var(--color-key-inactive-black-bg)' : (isPressed && isActiveOctave ? 'var(--color-text-secondary)' : 'var(--color-interactive-dark)'),
+      background: !isActive
+        ? 'var(--color-key-inactive-black-bg)'
+        : isPressed && isActiveOctave
+          ? 'var(--color-text-secondary)'
+          : 'var(--color-interactive-dark)',
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
@@ -504,7 +552,7 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
       top: '50%',
       transform: 'translateY(-50%)',
       left: '50%',
-      marginLeft: `-${circleSize / 2}px` // Half of width to center
+      marginLeft: `-${circleSize / 2}px`, // Half of width to center
     };
 
     const letterStyle = {
@@ -526,46 +574,48 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
           left: 'auto',
           right: '2px', // Account for outer ring size
           marginLeft: '0',
-          transform: 'translateY(-50%)' // Keep vertical centering
+          transform: 'translateY(-50%)', // Keep vertical centering
         };
       } else if (circleOffset === 'left') {
-        // R and Y keys - left aligned  
+        // R and Y keys - left aligned
         circleStyle = {
           ...circleStyle,
           left: '2px', // Account for outer ring size
           marginLeft: '0',
-          transform: 'translateY(-50%)' // Keep vertical centering
+          transform: 'translateY(-50%)', // Keep vertical centering
         };
       }
     }
 
     return (
-      <div style={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        gap: '0px'
-      }}>
-        
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '0px',
+        }}
+      >
         {/* Key button */}
         <button
           // data attributes are used by the mobile touch handler
           data-keychar={keyChar}
           data-octave={octave}
           // an empty onClick is for accessibility, but we prevent double-firing
-          onClick={(e) => { e.preventDefault(); }}
-          
+          onClick={(e) => {
+            e.preventDefault();
+          }}
           // --- MOUSE & PEN EVENTS ---
           onPointerDown={(e) => {
             // This handler is for MOUSE ONLY to preserve press-and-hold.
             // Touch is handled by the container.
             if (e.pointerType !== 'mouse') return;
             handleActivate();
-            setPressedKeys(prev => new Set(prev).add(`${keyChar}:${octave}`));
+            setPressedKeys((prev) => new Set(prev).add(`${keyChar}:${octave}`));
           }}
           onPointerUp={(e) => {
             if (e.pointerType !== 'mouse') return;
-            setPressedKeys(prev => {
+            setPressedKeys((prev) => {
               const newSet = new Set(prev);
               newSet.delete(`${keyChar}:${octave}`);
               return newSet;
@@ -573,34 +623,33 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
           }}
           onMouseLeave={(e) => {
             // Also clear visual state if mouse leaves while pressed down
-            if (e.buttons === 1) { // 1 means left mouse button is down
-              setPressedKeys(prev => {
+            if (e.buttons === 1) {
+              // 1 means left mouse button is down
+              setPressedKeys((prev) => {
                 const newSet = new Set(prev);
                 newSet.delete(`${keyChar}:${octave}`);
                 return newSet;
               });
             }
           }}
-          
           // --- KEYBOARD EVENTS ---
           onKeyDown={(e) => {
             if (e.key === 'Enter' || e.key === ' ') {
               e.preventDefault();
               handleActivate();
-              setPressedKeys(prev => new Set(prev).add(`${keyChar}:${octave}`));
+              setPressedKeys((prev) => new Set(prev).add(`${keyChar}:${octave}`));
             }
           }}
           onKeyUp={(e) => {
             if (e.key === 'Enter' || e.key === ' ') {
               e.preventDefault();
-              setPressedKeys(prev => {
+              setPressedKeys((prev) => {
                 const newSet = new Set(prev);
                 newSet.delete(`${keyChar}:${octave}`);
                 return newSet;
               });
             }
           }}
-          
           // --- DRAG & DROP AND ACCESSIBILITY ---
           tabIndex={0}
           role="button"
@@ -620,26 +669,42 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
             e.preventDefault();
             e.stopPropagation();
             // Remove visual feedback
-            e.currentTarget.style.background = !isActive ? 'var(--color-key-inactive-white-bg)' : (isPressed ? '#bdbdbd' : 'var(--color-keyboard-key-active-bg)');
+            e.currentTarget.style.background = !isActive
+              ? 'var(--color-key-inactive-white-bg)'
+              : isPressed
+                ? '#bdbdbd'
+                : 'var(--color-keyboard-key-active-bg)';
             e.currentTarget.style.transform = 'scale(1)';
-            e.currentTarget.style.boxShadow = isActive ? '0 4px 12px rgba(0, 0, 0, 0.18)' : '0 2px 6px rgba(0, 0, 0, 0.1)';
-            e.currentTarget.style.borderColor = !isActive ? 'var(--color-key-inactive-border)' : 'var(--color-black)';
+            e.currentTarget.style.boxShadow = isActive
+              ? '0 4px 12px rgba(0, 0, 0, 0.18)'
+              : '0 2px 6px rgba(0, 0, 0, 0.1)';
+            e.currentTarget.style.borderColor = !isActive
+              ? 'var(--color-key-inactive-border)'
+              : 'var(--color-black)';
           }}
           onDrop={(e) => {
             e.preventDefault();
             e.stopPropagation();
-            
+
             // Remove visual feedback
-            e.currentTarget.style.background = !isActive ? 'var(--color-key-inactive-white-bg)' : (isPressed ? '#bdbdbd' : 'var(--color-keyboard-key-active-bg)');
+            e.currentTarget.style.background = !isActive
+              ? 'var(--color-key-inactive-white-bg)'
+              : isPressed
+                ? '#bdbdbd'
+                : 'var(--color-keyboard-key-active-bg)';
             e.currentTarget.style.transform = 'scale(1)';
-            e.currentTarget.style.boxShadow = isActive ? '0 4px 12px rgba(0, 0, 0, 0.18)' : '0 2px 6px rgba(0, 0, 0, 0.1)';
-            e.currentTarget.style.borderColor = !isActive ? 'var(--color-key-inactive-border)' : 'var(--color-black)';
-            
+            e.currentTarget.style.boxShadow = isActive
+              ? '0 4px 12px rgba(0, 0, 0, 0.18)'
+              : '0 2px 6px rgba(0, 0, 0, 0.1)';
+            e.currentTarget.style.borderColor = !isActive
+              ? 'var(--color-key-inactive-border)'
+              : 'var(--color-black)';
+
             const files = Array.from(e.dataTransfer.files);
-            const audioFile = files.find(file => 
-              file.type.startsWith('audio/') || file.name.toLowerCase().endsWith('.wav')
+            const audioFile = files.find(
+              (file) => file.type.startsWith('audio/') || file.name.toLowerCase().endsWith('.wav')
             );
-            
+
             if (audioFile && mapping && onFileUpload) {
               onFileUpload(mapping.idx, audioFile);
             }
@@ -654,12 +719,16 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
             borderRadius: '3px',
             cursor: 'pointer',
             transition: 'all 0.1s ease',
-            background: !isActive ? 'var(--color-key-inactive-white-bg)' : (isPressed ? '#bdbdbd' : 'var(--color-keyboard-key-active-bg)'),
+            background: !isActive
+              ? 'var(--color-key-inactive-white-bg)'
+              : isPressed
+                ? '#bdbdbd'
+                : 'var(--color-keyboard-key-active-bg)',
             boxShadow: isActive ? '0 4px 12px rgba(0, 0, 0, 0.18)' : '0 2px 6px rgba(0, 0, 0, 0.1)',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
-            outline: 'none'
+            outline: 'none',
           }}
           onFocus={(e) => {
             // Add focus ring for keyboard navigation
@@ -672,65 +741,106 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
           }}
         >
           {/* Outer ring around black circle */}
-          <div style={{
-            ...circleStyle,
-            width: `${outerRingSize}px`,
-            height: `${outerRingSize}px`,
-            background: 'transparent',
-            border: !isActive ? '1px solid var(--color-key-inactive-border)' : '1px solid var(--color-black)',
-            marginLeft: circleStyle.marginLeft === '0' ? '0' : `-${outerRingSize / 2}px` // Conditional centering
-          }}>
+          <div
+            style={{
+              ...circleStyle,
+              width: `${outerRingSize}px`,
+              height: `${outerRingSize}px`,
+              background: 'transparent',
+              border: !isActive
+                ? '1px solid var(--color-key-inactive-border)'
+                : '1px solid var(--color-black)',
+              marginLeft: circleStyle.marginLeft === '0' ? '0' : `-${outerRingSize / 2}px`, // Conditional centering
+            }}
+          >
             {/* Inner black circle */}
-            <div style={{
-              width: `${circleSize}px`,
-              height: `${circleSize}px`,
-              borderRadius: '50%',
-              background: !isActive ? 'var(--color-key-inactive-black-bg)' : 'var(--color-black)',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              position: 'relative'
-            }}>
+            <div
+              style={{
+                width: `${circleSize}px`,
+                height: `${circleSize}px`,
+                borderRadius: '50%',
+                background: !isActive ? 'var(--color-key-inactive-black-bg)' : 'var(--color-black)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                position: 'relative',
+              }}
+            >
               {/* Computer key label - always visible when active octave */}
               {showKeyboardLabels && !isMobile && (
-                <div style={{
-                  ...letterStyle,
-                  color: !isActive ? 'var(--color-text-secondary)' : '#fff'
-                }}>
+                <div
+                  style={{
+                    ...letterStyle,
+                    color: !isActive ? 'var(--color-text-secondary)' : '#fff',
+                  }}
+                >
                   {keyChar.toUpperCase()}
                 </div>
               )}
             </div>
           </div>
-          
+
           {/* Drum label overlay - always visible */}
           {mapping && (
-            <div style={{
-              position: 'absolute',
-              top: '2px',
-              left: '2px',
-              right: '2px',
-              bottom: '2px',
-              display: 'flex',
-              alignItems: 'flex-start',
-              justifyContent: 'flex-start',
-              pointerEvents: 'none',
-              zIndex: 2
-            }}>
-              <div 
+            <div
+              style={{
+                position: 'absolute',
+                top: '2px',
+                left: '2px',
+                right: '2px',
+                bottom: '2px',
+                display: 'flex',
+                alignItems: 'flex-start',
+                justifyContent: 'flex-start',
+                pointerEvents: 'none',
+                zIndex: 2,
+              }}
+            >
+              <div
                 id={`drum-key-${mapping.idx}-${octave}`}
                 style={{
                   backgroundColor: 'var(--color-border-primary)', // slate from theme
                   color: '#fff', // white text
-                  fontSize: `${baseSize * (9/56)}px`,
+                  fontSize: `${baseSize * (9 / 56)}px`,
                   fontWeight: '600',
-                  padding: `${baseSize * (2/56)}px ${baseSize * (4/56)}px`,
+                  padding: `${baseSize * (2 / 56)}px ${baseSize * (4 / 56)}px`,
                   borderRadius: '2px',
                   lineHeight: '1',
-                  letterSpacing: '0.5px'
+                  letterSpacing: '0.5px',
                 }}
               >
                 {mapping.label}
+              </div>
+            </div>
+          )}
+
+          {/* Organize mode indicator overlay */}
+          {isOrganizeMode && (isWhiteKey || isBlackKey) && (
+            <div
+              style={{
+                position: 'absolute',
+                bottom: '2px',
+                right: '2px',
+                pointerEvents: 'none',
+                zIndex: 3,
+              }}
+            >
+              <div
+                style={{
+                  backgroundColor: isWhiteKey
+                    ? 'rgba(76, 175, 80, 0.85)'
+                    : 'rgba(255, 152, 0, 0.85)',
+                  color: '#fff',
+                  fontSize: `${baseSize * (7 / 56)}px`,
+                  fontWeight: '700',
+                  padding: `${baseSize * (1 / 56)}px ${baseSize * (3 / 56)}px`,
+                  borderRadius: '2px',
+                  lineHeight: '1',
+                  letterSpacing: '0.3px',
+                  textTransform: 'uppercase',
+                }}
+              >
+                {isWhiteKey ? 'lower' : 'upper'}
               </div>
             </div>
           )}
@@ -740,12 +850,12 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
   };
 
   return (
-    <div 
+    <div
       role="group"
       aria-label="Drum keyboard"
-      style={{ 
+      style={{
         fontFamily: '"Montserrat", "Arial", sans-serif',
-        userSelect: 'none'
+        userSelect: 'none',
       }}
     >
       {/* Hidden file input for browsing files */}
@@ -756,11 +866,11 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
         style={{ display: 'none' }}
         onChange={handleFileSelect}
       />
-      
+
       {/* Mobile Layout - Single Octave with Swipe */}
       {isMobile ? (
         <>
-          <div 
+          <div
             style={{
               padding: '3px',
               background: 'transparent',
@@ -770,7 +880,7 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
               width: '100%',
               boxShadow: '0 2px 8px var(--color-shadow-primary)',
               position: 'relative',
-              marginBottom: '8px' // even less space for dots below
+              marginBottom: '8px', // even less space for dots below
             }}
             onTouchStart={handleTouchStart}
             onTouchMove={handleTouchMove}
@@ -778,35 +888,49 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
           >
             {/* Swipe Hint Overlay */}
             {showSwipeHint && (
-              <div style={{
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                right: 0,
-                bottom: 0,
-                background: 'rgba(0, 0, 0, 0.7)',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                zIndex: 20,
-                borderRadius: '6px'
-              }}>
-                <div style={{
-                  background: 'var(--color-bg-primary)',
-                  padding: '16px',
+              <div
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  background: 'rgba(0, 0, 0, 0.7)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  zIndex: 20,
                   borderRadius: '6px',
-                  textAlign: 'center',
-                  maxWidth: '280px',
-                  margin: '0 16px'
-                }}>
-                  <div style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    gap: '8px',
-                    marginBottom: '12px'
-                  }}>
-                    <span style={{ color: 'var(--color-text-primary)', fontSize: '0.875rem', fontWeight: '500' }}>swipe to change octaves</span>
+                }}
+              >
+                <div
+                  style={{
+                    background: 'var(--color-bg-primary)',
+                    padding: '16px',
+                    borderRadius: '6px',
+                    textAlign: 'center',
+                    maxWidth: '280px',
+                    margin: '0 16px',
+                  }}
+                >
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      gap: '8px',
+                      marginBottom: '12px',
+                    }}
+                  >
+                    <span
+                      style={{
+                        color: 'var(--color-text-primary)',
+                        fontSize: '0.875rem',
+                        fontWeight: '500',
+                      }}
+                    >
+                      swipe to change octaves
+                    </span>
                   </div>
                   <button
                     onClick={() => {
@@ -821,7 +945,7 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
                       borderRadius: '3px',
                       fontSize: '0.75rem',
                       fontWeight: '500',
-                      cursor: 'pointer'
+                      cursor: 'pointer',
                     }}
                   >
                     got it
@@ -831,33 +955,38 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
             )}
 
             {/* Viewport for clipping */}
-            <div 
+            <div
               ref={containerRef}
               style={{
                 position: 'relative',
                 overflow: 'hidden',
                 width: '100%',
-                background: 'transparent'
-              }}>
+                background: 'transparent',
+              }}
+            >
               {/* Sliding track */}
-              <div style={{
-                display: 'flex',
-                width: '200%',
-                transform: `translateX(${currentOctave === 0 ? '0' : '-50%'})`,
-                transition: 'transform 0.3s ease-out'
-              }}>
+              <div
+                style={{
+                  display: 'flex',
+                  width: '200%',
+                  transform: `translateX(${currentOctave === 0 ? '0' : '-50%'})`,
+                  transition: 'transform 0.3s ease-out',
+                }}
+              >
                 {/* Octave 0 Panel */}
-                <div 
+                <div
                   role="group"
                   aria-label="Lower octave drum keys"
                   style={{ width: '50%', flexShrink: 0 }}
                 >
-                  <div style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'center',
-                    gap: '1px'
-                  }}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      gap: '1px',
+                    }}
+                  >
                     {/* Top row */}
                     <div style={{ display: 'flex', gap: '1px' }}>
                       <OPXYKey {...createLargeKeyProps('W', 0, 'right')} />
@@ -868,25 +997,30 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
                     </div>
                     {/* Bottom row */}
                     <div style={{ display: 'flex', gap: '1px' }}>
-                      {['A', 'S', 'D', 'F', 'G', 'H', 'J'].map(key => (
-                        <OPXYKey key={`octave0-mobile-${key}`} {...createStandardKeyProps(key, 0)} />
+                      {['A', 'S', 'D', 'F', 'G', 'H', 'J'].map((key) => (
+                        <OPXYKey
+                          key={`octave0-mobile-${key}`}
+                          {...createStandardKeyProps(key, 0)}
+                        />
                       ))}
                     </div>
                   </div>
                 </div>
 
                 {/* Octave 1 Panel */}
-                <div 
+                <div
                   role="group"
                   aria-label="Upper octave drum keys"
                   style={{ width: '50%', flexShrink: 0 }}
                 >
-                  <div style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    alignItems: 'center',
-                    gap: '1px'
-                  }}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      gap: '1px',
+                    }}
+                  >
                     {/* Top row */}
                     <div style={{ display: 'flex', gap: '1px' }}>
                       <OPXYKey {...createLargeKeyProps('W', 1, 'right')} />
@@ -897,8 +1031,11 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
                     </div>
                     {/* Bottom row */}
                     <div style={{ display: 'flex', gap: '1px' }}>
-                      {['A', 'S', 'D', 'F', 'G', 'H', 'J'].map(key => (
-                        <OPXYKey key={`octave1-mobile-${key}`} {...createStandardKeyProps(key, 1)} />
+                      {['A', 'S', 'D', 'F', 'G', 'H', 'J'].map((key) => (
+                        <OPXYKey
+                          key={`octave1-mobile-${key}`}
+                          {...createStandardKeyProps(key, 1)}
+                        />
                       ))}
                     </div>
                   </div>
@@ -907,156 +1044,168 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
             </div>
           </div>
           {/* Swipe Indicator Dots - now outside the keyboard border */}
-          <div style={{
-            position: 'relative',
-            width: '100%',
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            marginTop: '-2px', // very tight to keyboard border
-            marginBottom: '0px',
-            zIndex: 1
-          }}>
-            <div style={{
-              width: '8px',
-              height: '8px',
-              borderRadius: '50%',
-              background: currentOctave === 0 ? 'var(--color-text-secondary)' : 'var(--color-border-light)',
-              transition: 'background-color 0.3s ease',
-              margin: '0 4px'
-            }}></div>
-            <div style={{
-              width: '8px',
-              height: '8px',
-              borderRadius: '50%',
-              background: currentOctave === 1 ? 'var(--color-text-secondary)' : 'var(--color-border-light)',
-              transition: 'background-color 0.3s ease',
-              margin: '0 4px'
-            }}></div>
+          <div
+            style={{
+              position: 'relative',
+              width: '100%',
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              marginTop: '-2px', // very tight to keyboard border
+              marginBottom: '0px',
+              zIndex: 1,
+            }}
+          >
+            <div
+              style={{
+                width: '8px',
+                height: '8px',
+                borderRadius: '50%',
+                background:
+                  currentOctave === 0 ? 'var(--color-text-secondary)' : 'var(--color-border-light)',
+                transition: 'background-color 0.3s ease',
+                margin: '0 4px',
+              }}
+            ></div>
+            <div
+              style={{
+                width: '8px',
+                height: '8px',
+                borderRadius: '50%',
+                background:
+                  currentOctave === 1 ? 'var(--color-text-secondary)' : 'var(--color-border-light)',
+                transition: 'background-color 0.3s ease',
+                margin: '0 4px',
+              }}
+            ></div>
           </div>
         </>
       ) : (
         /* Desktop Layout - Both Octaves Side by Side */
-        <div style={{
-          display: 'flex',
-          justifyContent: 'center',
-          margin: '1px',
-          width: 'calc(100% - 2px)',
-          padding: '1rem'
-        }}>
-          <div style={{
-            display: 'inline-flex',
-            flexDirection: 'row',
-            alignItems: 'center',
-            gap: '1px',
-            padding: '3px',
-            background: '#f8f9fa',
-            border: '1px solid #ddd',
-            borderRadius: '6px',
-            overflow: 'hidden',
-            boxSizing: 'border-box',
-            boxShadow: '0 2px 8px var(--color-shadow-primary)'
-          }}>
-          {/* Octave 1 (Lower) */}
-          <div 
-            role="group"
-            aria-label="Lower octave drum keys"
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            margin: '1px',
+            width: 'calc(100% - 2px)',
+            padding: '1rem',
+          }}
+        >
+          <div
             style={{
-              display: 'flex',
-              flexDirection: 'column',
+              display: 'inline-flex',
+              flexDirection: 'row',
               alignItems: 'center',
               gap: '1px',
-              position: 'relative'
+              padding: '3px',
+              background: '#f8f9fa',
+              border: '1px solid #ddd',
+              borderRadius: '6px',
+              overflow: 'hidden',
+              boxSizing: 'border-box',
+              boxShadow: '0 2px 8px var(--color-shadow-primary)',
             }}
           >
-            
-            {/* Top row */}
-            <div style={{ 
-              display: 'flex', 
-              gap: '1px', 
-              alignItems: 'flex-end',
-              width: '100%',
-              maxWidth: '100%',
-              justifyContent: 'center',
-              overflow: 'hidden'
-            }}>
-              <OPXYKey {...createLargeKeyProps('W', 0, 'right')} />
-              <OPXYKey {...createStandardKeyProps('E', 0)} />
-              <OPXYKey {...createLargeKeyProps('R', 0, 'left')} />
-              <OPXYKey {...createLargeKeyProps('Y', 0, 'right')} />
-              <OPXYKey {...createLargeKeyProps('U', 0, 'left')} />
+            {/* Octave 1 (Lower) */}
+            <div
+              role="group"
+              aria-label="Lower octave drum keys"
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: '1px',
+                position: 'relative',
+              }}
+            >
+              {/* Top row */}
+              <div
+                style={{
+                  display: 'flex',
+                  gap: '1px',
+                  alignItems: 'flex-end',
+                  width: '100%',
+                  maxWidth: '100%',
+                  justifyContent: 'center',
+                  overflow: 'hidden',
+                }}
+              >
+                <OPXYKey {...createLargeKeyProps('W', 0, 'right')} />
+                <OPXYKey {...createStandardKeyProps('E', 0)} />
+                <OPXYKey {...createLargeKeyProps('R', 0, 'left')} />
+                <OPXYKey {...createLargeKeyProps('Y', 0, 'right')} />
+                <OPXYKey {...createLargeKeyProps('U', 0, 'left')} />
+              </div>
+
+              {/* Bottom row */}
+              <div
+                style={{
+                  display: 'flex',
+                  gap: '1px',
+                  alignItems: 'flex-start',
+                  width: '100%',
+                  maxWidth: '100%',
+                  justifyContent: 'center',
+                  overflow: 'hidden',
+                }}
+              >
+                {['A', 'S', 'D', 'F', 'G', 'H', 'J'].map((key) => (
+                  <OPXYKey key={`octave0-${key}`} {...createStandardKeyProps(key, 0)} />
+                ))}
+              </div>
             </div>
 
-            {/* Bottom row */}
-            <div style={{ 
-              display: 'flex', 
-              gap: '1px',
-              alignItems: 'flex-start',
-              width: '100%',
-              maxWidth: '100%',
-              justifyContent: 'center',
-              overflow: 'hidden'
-            }}>
-              {['A', 'S', 'D', 'F', 'G', 'H', 'J'].map(key => (
-                <OPXYKey
-                  key={`octave0-${key}`}
-                  {...createStandardKeyProps(key, 0)}
-                />
-              ))}
-            </div>
-          </div>
+            {/* Octave 2 (Upper) */}
+            <div
+              role="group"
+              aria-label="Upper octave drum keys"
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: '1px',
+                position: 'relative',
+              }}
+            >
+              {/* Top row */}
+              <div
+                style={{
+                  display: 'flex',
+                  gap: '1px',
+                  alignItems: 'flex-end',
+                  width: '100%',
+                  maxWidth: '100%',
+                  justifyContent: 'center',
+                  overflow: 'hidden',
+                }}
+              >
+                <OPXYKey {...createLargeKeyProps('W', 1, 'right')} />
+                <OPXYKey {...createStandardKeyProps('E', 1)} />
+                <OPXYKey {...createLargeKeyProps('R', 1, 'left')} />
+                <OPXYKey {...createLargeKeyProps('Y', 1, 'right')} />
+                <OPXYKey {...createLargeKeyProps('U', 1, 'left')} />
+              </div>
 
-          {/* Octave 2 (Upper) */}
-          <div 
-            role="group"
-            aria-label="Upper octave drum keys"
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              gap: '1px',
-              position: 'relative'
-            }}
-          >
-            
-            {/* Top row */}
-            <div style={{ 
-              display: 'flex', 
-              gap: '1px', 
-              alignItems: 'flex-end',
-              width: '100%',
-              maxWidth: '100%',
-              justifyContent: 'center',
-              overflow: 'hidden'
-            }}>
-              <OPXYKey {...createLargeKeyProps('W', 1, 'right')} />
-              <OPXYKey {...createStandardKeyProps('E', 1)} />
-              <OPXYKey {...createLargeKeyProps('R', 1, 'left')} />
-              <OPXYKey {...createLargeKeyProps('Y', 1, 'right')} />
-              <OPXYKey {...createLargeKeyProps('U', 1, 'left')} />
+              {/* Bottom row */}
+              <div
+                style={{
+                  display: 'flex',
+                  gap: '1px',
+                  alignItems: 'flex-start',
+                  width: '100%',
+                  maxWidth: '100%',
+                  justifyContent: 'center',
+                  overflow: 'hidden',
+                }}
+              >
+                {['A', 'S', 'D', 'F', 'G', 'H', 'J'].map((key) => (
+                  <OPXYKey key={`octave1-${key}`} {...createStandardKeyProps(key, 1)} />
+                ))}
+              </div>
             </div>
-
-            {/* Bottom row */}
-            <div style={{ 
-              display: 'flex', 
-              gap: '1px',
-              alignItems: 'flex-start',
-              width: '100%',
-              maxWidth: '100%',
-              justifyContent: 'center',
-              overflow: 'hidden'
-            }}>
-              {['A', 'S', 'D', 'F', 'G', 'H', 'J'].map(key => (
-                <OPXYKey
-                  key={`octave1-${key}`}
-                  {...createStandardKeyProps(key, 1)}
-                />
-              ))}
-            </div>
-          </div>
           </div>
         </div>
       )}
     </div>
   );
-} 
+}

--- a/src/components/drum/DrumKeyboardContainer.tsx
+++ b/src/components/drum/DrumKeyboardContainer.tsx
@@ -48,6 +48,7 @@ export const DrumKeyboardContainer: React.FC<DrumKeyboardContainerProps> = ({ on
   // MIDI event handling
   const { onMidiEvent, state: midiState, initialize, refreshDevices } = useWebMidi();
   const [isMidiSelectorVisible, setIsMidiSelectorVisible] = useState(false);
+  const [isOrganizeMode, setIsOrganizeMode] = useState(false);
 
   // Auto-initialize MIDI if not already initialized
   useEffect(() => {
@@ -60,7 +61,6 @@ export const DrumKeyboardContainer: React.FC<DrumKeyboardContainerProps> = ({ on
   useEffect(() => {
     const handleVisibilityChange = () => {
       if (!document.hidden && midiState.isInitialized) {
-
         refreshDevices();
       }
     };
@@ -93,12 +93,12 @@ export const DrumKeyboardContainer: React.FC<DrumKeyboardContainerProps> = ({ on
     return () => cleanup();
   }, [onMidiEvent]);
 
-  const loadedSamplesCount = state.drumSamples.filter(sample => sample && sample.isLoaded).length;
+  const loadedSamplesCount = state.drumSamples.filter((sample) => sample && sample.isLoaded).length;
 
   const togglePin = () => {
     const newPinnedState = !isDrumKeyboardPinned;
     setIsDrumKeyboardPinned(newPinnedState);
-    
+
     // If unpinning while stuck, reset stuck state without scrolling
     if (!newPinnedState && isStuck) {
       setDynamicStyles({});
@@ -120,16 +120,30 @@ export const DrumKeyboardContainer: React.FC<DrumKeyboardContainerProps> = ({ on
   const tooltipContent = isMobile ? (
     <>
       <h3>keyboard controls</h3>
-      <p><strong>load:</strong> tap empty keys to browse and select files</p>
-      <p><strong>play:</strong> tap keys to play loaded samples</p>
-      <p><strong>pin:</strong> use the pin icon to keep the keyboard at the top of the screen</p>
+      <p>
+        <strong>load:</strong> tap empty keys to browse and select files
+      </p>
+      <p>
+        <strong>play:</strong> tap keys to play loaded samples
+      </p>
+      <p>
+        <strong>pin:</strong> use the pin icon to keep the keyboard at the top of the screen
+      </p>
     </>
   ) : (
     <>
       <h3>keyboard controls</h3>
-      <p><strong>load:</strong> click empty keys to browse files or drag and drop audio files directly onto any key</p>
-      <p><strong>play:</strong> use keyboard keys (<strong>A-J, W, E, R, Y, U</strong>) to trigger samples and <strong>Z</strong> / <strong>X</strong> to switch octaves</p>
-      <p><strong>pin:</strong> use the pin icon to keep the keyboard at the top of the screen</p>
+      <p>
+        <strong>load:</strong> click empty keys to browse files or drag and drop audio files
+        directly onto any key
+      </p>
+      <p>
+        <strong>play:</strong> use keyboard keys (<strong>A-J, W, E, R, Y, U</strong>) to trigger
+        samples and <strong>Z</strong> / <strong>X</strong> to switch octaves
+      </p>
+      <p>
+        <strong>pin:</strong> use the pin icon to keep the keyboard at the top of the screen
+      </p>
     </>
   );
 
@@ -153,7 +167,10 @@ export const DrumKeyboardContainer: React.FC<DrumKeyboardContainerProps> = ({ on
         if (rect.top <= 10) {
           // Stick
           setPlaceholderHeight(rect.height);
-          setDynamicStyles({ left: `${rect.left}px`, width: `${rect.width}px` });
+          setDynamicStyles({
+            left: `${rect.left}px`,
+            width: `${rect.width}px`,
+          });
           setIsStuck(true);
         }
       } else {
@@ -200,7 +217,11 @@ export const DrumKeyboardContainer: React.FC<DrumKeyboardContainerProps> = ({ on
       {/* Placeholder to avoid layout shift */}
       <div
         ref={placeholderRef}
-        style={{ display: isStuck ? 'block' : 'none', height: `${placeholderHeight}px`, background: '#fff' }}
+        style={{
+          display: isStuck ? 'block' : 'none',
+          height: `${placeholderHeight}px`,
+          background: '#fff',
+        }}
       />
 
       {/* Actual Keyboard Container */}
@@ -231,10 +252,7 @@ export const DrumKeyboardContainer: React.FC<DrumKeyboardContainerProps> = ({ on
             >
               load and play samples
             </h3>
-            <EnhancedTooltip
-              isVisible={isTooltipVisible}
-              content={tooltipContent}
-            >
+            <EnhancedTooltip isVisible={isTooltipVisible} content={tooltipContent}>
               <span
                 style={{ display: 'flex' }}
                 onClick={(e) => {
@@ -244,16 +262,16 @@ export const DrumKeyboardContainer: React.FC<DrumKeyboardContainerProps> = ({ on
                 onMouseEnter={() => setIsTooltipVisible(true)}
                 onMouseLeave={() => setIsTooltipVisible(false)}
               >
-                <i 
-                  className="fas fa-question-circle" 
-                  style={{ 
-                    fontSize: iconSize, 
+                <i
+                  className="fas fa-question-circle"
+                  style={{
+                    fontSize: iconSize,
                     color: 'var(--color-text-secondary)',
-                    cursor: 'help'
+                    cursor: 'help',
                   }}
                 />
               </span>
-                          </EnhancedTooltip>
+            </EnhancedTooltip>
           </div>
           <div
             style={{
@@ -274,21 +292,66 @@ export const DrumKeyboardContainer: React.FC<DrumKeyboardContainerProps> = ({ on
                     fontWeight: 500,
                   }}
                 >
-                  <i className="fas fa-check-circle" style={{ color: 'var(--color-text-secondary)', fontSize: iconSize }}></i>
+                  <i
+                    className="fas fa-check-circle"
+                    style={{
+                      color: 'var(--color-text-secondary)',
+                      fontSize: iconSize,
+                    }}
+                  ></i>
                   {loadedSamplesCount} / 24 loaded
                 </div>
                 <button
+                  onClick={() => setIsOrganizeMode(!isOrganizeMode)}
+                  style={{
+                    background: isOrganizeMode
+                      ? 'var(--color-interactive-focus)'
+                      : 'var(--color-text-secondary)',
+                    border: 'none',
+                    cursor: 'pointer',
+                    padding: '0.25rem 0.5rem',
+                    borderRadius: '3px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '0.25rem',
+                    fontSize: '0.875rem',
+                    color: 'var(--color-white)',
+                    transition: 'all 0.2s ease',
+                    fontFamily: '"Montserrat", "Arial", sans-serif',
+                    fontWeight: 500,
+                    minHeight: '32px',
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.backgroundColor = isOrganizeMode
+                      ? 'var(--color-interactive-dark)'
+                      : 'var(--color-interactive-focus)';
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.backgroundColor = isOrganizeMode
+                      ? 'var(--color-interactive-focus)'
+                      : 'var(--color-text-secondary)';
+                  }}
+                  title="organize mode: bulk load upper and lower rows"
+                >
+                  <i className="fas fa-layer-group" style={{ fontSize: '0.75rem' }}></i>
+                  <span>organize</span>
+                </button>
+                <button
                   onClick={() => {
                     setIsMidiSelectorVisible(!isMidiSelectorVisible);
-                    const midiSelector = document.querySelector('.midi-device-selector') as HTMLElement;
+                    const midiSelector = document.querySelector(
+                      '.midi-device-selector'
+                    ) as HTMLElement;
                     if (midiSelector) {
                       midiSelector.style.display = isMidiSelectorVisible ? 'none' : 'block';
                     }
                   }}
                   style={{
-                    background: isMidiSelectorVisible 
-                      ? 'var(--color-interactive-focus)' 
-                      : midiState.devices.filter(d => d.type === 'input' && d.state === 'connected').length > 0
+                    background: isMidiSelectorVisible
+                      ? 'var(--color-interactive-focus)'
+                      : midiState.devices.filter(
+                            (d) => d.type === 'input' && d.state === 'connected'
+                          ).length > 0
                         ? 'var(--color-text-primary)'
                         : 'var(--color-text-secondary)',
                     border: 'none',
@@ -303,20 +366,24 @@ export const DrumKeyboardContainer: React.FC<DrumKeyboardContainerProps> = ({ on
                     transition: 'all 0.2s ease',
                     fontFamily: '"Montserrat", "Arial", sans-serif',
                     fontWeight: 500,
-                    minHeight: '32px'
+                    minHeight: '32px',
                   }}
-                  onMouseEnter={e => {
-                    const hasConnectedDevices = midiState.devices.filter(d => d.type === 'input' && d.state === 'connected').length > 0;
-                    e.currentTarget.style.backgroundColor = isMidiSelectorVisible 
-                      ? 'var(--color-interactive-dark)' 
+                  onMouseEnter={(e) => {
+                    const hasConnectedDevices =
+                      midiState.devices.filter((d) => d.type === 'input' && d.state === 'connected')
+                        .length > 0;
+                    e.currentTarget.style.backgroundColor = isMidiSelectorVisible
+                      ? 'var(--color-interactive-dark)'
                       : hasConnectedDevices
                         ? 'var(--color-interactive-focus)'
                         : 'var(--color-interactive-focus)';
                   }}
-                  onMouseLeave={e => {
-                    const hasConnectedDevices = midiState.devices.filter(d => d.type === 'input' && d.state === 'connected').length > 0;
-                    e.currentTarget.style.backgroundColor = isMidiSelectorVisible 
-                      ? 'var(--color-interactive-focus)' 
+                  onMouseLeave={(e) => {
+                    const hasConnectedDevices =
+                      midiState.devices.filter((d) => d.type === 'input' && d.state === 'connected')
+                        .length > 0;
+                    e.currentTarget.style.backgroundColor = isMidiSelectorVisible
+                      ? 'var(--color-interactive-focus)'
                       : hasConnectedDevices
                         ? 'var(--color-text-primary)'
                         : 'var(--color-text-secondary)';
@@ -344,23 +411,24 @@ export const DrumKeyboardContainer: React.FC<DrumKeyboardContainerProps> = ({ on
               }}
               title={isDrumKeyboardPinned ? 'Unpin keyboard' : 'Pin keyboard to top'}
             >
-              <i className="fas fa-thumbtack" style={{ 
-                fontSize: iconSize,
-              }}></i>
+              <i
+                className="fas fa-thumbtack"
+                style={{
+                  fontSize: iconSize,
+                }}
+              ></i>
             </button>
           </div>
         </div>
 
-
-
         {/* MIDI Device Selector (Hidden by default) */}
-        <div 
+        <div
           className="midi-device-selector"
-          style={{ 
+          style={{
             display: isMidiSelectorVisible ? 'block' : 'none',
             padding: '0.75rem 1rem',
             backgroundColor: 'var(--color-bg-primary)',
-            borderBottom: '1px solid var(--color-border-light)'
+            borderBottom: '1px solid var(--color-border-light)',
           }}
         >
           <MidiDeviceSelector
@@ -374,13 +442,210 @@ export const DrumKeyboardContainer: React.FC<DrumKeyboardContainerProps> = ({ on
         </div>
 
         {/* Keyboard */}
-        <DrumKeyboard 
+        <DrumKeyboard
           onFileUpload={onFileUpload}
           selectedMidiChannel={selectedMidiChannel}
           midiState={midiState}
           onMidiEventExternal={onMidiEvent}
+          isOrganizeMode={isOrganizeMode}
         />
+
+        {/* Organize Mode Drop Zones */}
+        {isOrganizeMode && !isMobile && (
+          <div
+            style={{
+              display: 'flex',
+              gap: '1rem',
+              padding: '1rem',
+              borderTop: '1px solid var(--color-border-light)',
+            }}
+          >
+            {/* Kicks Drop Zone */}
+            <div
+              onDragOver={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                e.currentTarget.style.borderColor = 'rgba(76, 175, 80, 0.8)';
+                e.currentTarget.style.backgroundColor = 'rgba(76, 175, 80, 0.1)';
+              }}
+              onDragLeave={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                e.currentTarget.style.borderColor = 'rgba(76, 175, 80, 0.3)';
+                e.currentTarget.style.backgroundColor = 'transparent';
+              }}
+              onDrop={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                e.currentTarget.style.borderColor = 'rgba(76, 175, 80, 0.3)';
+                e.currentTarget.style.backgroundColor = 'transparent';
+
+                const files = Array.from(e.dataTransfer.files).filter(
+                  (file) =>
+                    file.type.startsWith('audio/') || file.name.toLowerCase().endsWith('.wav')
+                );
+
+                // White key indices for both octaves (A, S, D, F, G, H, J)
+                const whiteKeyIndices = [
+                  0,
+                  2,
+                  4,
+                  6,
+                  7,
+                  9,
+                  11, // Octave 0
+                  12,
+                  14,
+                  16,
+                  18,
+                  19,
+                  21,
+                  23, // Octave 1
+                ];
+
+                files.forEach((file, index) => {
+                  if (index < whiteKeyIndices.length && onFileUpload) {
+                    onFileUpload(whiteKeyIndices[index], file);
+                  }
+                });
+              }}
+              style={{
+                flex: 1,
+                border: '2px dashed rgba(76, 175, 80, 0.3)',
+                borderRadius: '6px',
+                padding: '2rem',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: '0.5rem',
+                cursor: 'pointer',
+                transition: 'all 0.2s ease',
+                minHeight: '120px',
+              }}
+            >
+              <i
+                className="fas fa-file-audio"
+                style={{
+                  fontSize: '2rem',
+                  color: 'rgba(76, 175, 80, 0.8)',
+                }}
+              ></i>
+              <div
+                style={{
+                  fontSize: '1rem',
+                  fontWeight: '600',
+                  color: 'rgba(76, 175, 80, 0.9)',
+                  textTransform: 'uppercase',
+                }}
+              >
+                drop lower row here
+              </div>
+              <div
+                style={{
+                  fontSize: '0.75rem',
+                  color: 'var(--color-text-secondary)',
+                  textAlign: 'center',
+                }}
+              >
+                bottom row (A, S, D, F, G, H, J)
+                <br />
+                up to 14 files
+              </div>
+            </div>
+
+            {/* Snares Drop Zone */}
+            <div
+              onDragOver={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                e.currentTarget.style.borderColor = 'rgba(255, 152, 0, 0.8)';
+                e.currentTarget.style.backgroundColor = 'rgba(255, 152, 0, 0.1)';
+              }}
+              onDragLeave={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                e.currentTarget.style.borderColor = 'rgba(255, 152, 0, 0.3)';
+                e.currentTarget.style.backgroundColor = 'transparent';
+              }}
+              onDrop={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                e.currentTarget.style.borderColor = 'rgba(255, 152, 0, 0.3)';
+                e.currentTarget.style.backgroundColor = 'transparent';
+
+                const files = Array.from(e.dataTransfer.files).filter(
+                  (file) =>
+                    file.type.startsWith('audio/') || file.name.toLowerCase().endsWith('.wav')
+                );
+
+                // Black key indices for both octaves (W, E, R, Y, U)
+                const blackKeyIndices = [
+                  1,
+                  3,
+                  5,
+                  8,
+                  10, // Octave 0
+                  13,
+                  15,
+                  17,
+                  20,
+                  22, // Octave 1
+                ];
+
+                files.forEach((file, index) => {
+                  if (index < blackKeyIndices.length && onFileUpload) {
+                    onFileUpload(blackKeyIndices[index], file);
+                  }
+                });
+              }}
+              style={{
+                flex: 1,
+                border: '2px dashed rgba(255, 152, 0, 0.3)',
+                borderRadius: '6px',
+                padding: '2rem',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: '0.5rem',
+                cursor: 'pointer',
+                transition: 'all 0.2s ease',
+                minHeight: '120px',
+              }}
+            >
+              <i
+                className="fas fa-file-audio"
+                style={{
+                  fontSize: '2rem',
+                  color: 'rgba(255, 152, 0, 0.8)',
+                }}
+              ></i>
+              <div
+                style={{
+                  fontSize: '1rem',
+                  fontWeight: '600',
+                  color: 'rgba(255, 152, 0, 0.9)',
+                  textTransform: 'uppercase',
+                }}
+              >
+                drop upper row here
+              </div>
+              <div
+                style={{
+                  fontSize: '0.75rem',
+                  color: 'var(--color-text-secondary)',
+                  textAlign: 'center',
+                }}
+              >
+                top row (W, E, R, Y, U)
+                <br />
+                up to 10 files
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </>
   );
-}; 
+};

--- a/src/components/drum/DrumKeyboardContainer.tsx
+++ b/src/components/drum/DrumKeyboardContainer.tsx
@@ -134,12 +134,11 @@ export const DrumKeyboardContainer: React.FC<DrumKeyboardContainerProps> = ({ on
     <>
       <h3>keyboard controls</h3>
       <p>
-        <strong>load:</strong> click empty keys to browse files or drag and drop audio files
-        directly onto any key
+        <strong>load:</strong> click empty keys to browse files or drag and drop audio files directly onto any key
       </p>
       <p>
-        <strong>play:</strong> use keyboard keys (<strong>A-J, W, E, R, Y, U</strong>) to trigger
-        samples and <strong>Z</strong> / <strong>X</strong> to switch octaves
+        <strong>play:</strong> use keyboard keys (<strong>A-J, W, E, R, Y, U</strong>) to trigger samples and{' '}
+        <strong>Z</strong> / <strong>X</strong> to switch octaves
       </p>
       <p>
         <strong>pin:</strong> use the pin icon to keep the keyboard at the top of the screen
@@ -304,9 +303,7 @@ export const DrumKeyboardContainer: React.FC<DrumKeyboardContainerProps> = ({ on
                 <button
                   onClick={() => setIsOrganizeMode(!isOrganizeMode)}
                   style={{
-                    background: isOrganizeMode
-                      ? 'var(--color-interactive-focus)'
-                      : 'var(--color-text-secondary)',
+                    background: isOrganizeMode ? 'var(--color-interactive-focus)' : 'var(--color-text-secondary)',
                     border: 'none',
                     cursor: 'pointer',
                     padding: '0.25rem 0.5rem',
@@ -339,9 +336,7 @@ export const DrumKeyboardContainer: React.FC<DrumKeyboardContainerProps> = ({ on
                 <button
                   onClick={() => {
                     setIsMidiSelectorVisible(!isMidiSelectorVisible);
-                    const midiSelector = document.querySelector(
-                      '.midi-device-selector'
-                    ) as HTMLElement;
+                    const midiSelector = document.querySelector('.midi-device-selector') as HTMLElement;
                     if (midiSelector) {
                       midiSelector.style.display = isMidiSelectorVisible ? 'none' : 'block';
                     }
@@ -349,9 +344,7 @@ export const DrumKeyboardContainer: React.FC<DrumKeyboardContainerProps> = ({ on
                   style={{
                     background: isMidiSelectorVisible
                       ? 'var(--color-interactive-focus)'
-                      : midiState.devices.filter(
-                            (d) => d.type === 'input' && d.state === 'connected'
-                          ).length > 0
+                      : midiState.devices.filter((d) => d.type === 'input' && d.state === 'connected').length > 0
                         ? 'var(--color-text-primary)'
                         : 'var(--color-text-secondary)',
                     border: 'none',
@@ -370,8 +363,7 @@ export const DrumKeyboardContainer: React.FC<DrumKeyboardContainerProps> = ({ on
                   }}
                   onMouseEnter={(e) => {
                     const hasConnectedDevices =
-                      midiState.devices.filter((d) => d.type === 'input' && d.state === 'connected')
-                        .length > 0;
+                      midiState.devices.filter((d) => d.type === 'input' && d.state === 'connected').length > 0;
                     e.currentTarget.style.backgroundColor = isMidiSelectorVisible
                       ? 'var(--color-interactive-dark)'
                       : hasConnectedDevices
@@ -380,8 +372,7 @@ export const DrumKeyboardContainer: React.FC<DrumKeyboardContainerProps> = ({ on
                   }}
                   onMouseLeave={(e) => {
                     const hasConnectedDevices =
-                      midiState.devices.filter((d) => d.type === 'input' && d.state === 'connected')
-                        .length > 0;
+                      midiState.devices.filter((d) => d.type === 'input' && d.state === 'connected').length > 0;
                     e.currentTarget.style.backgroundColor = isMidiSelectorVisible
                       ? 'var(--color-interactive-focus)'
                       : hasConnectedDevices
@@ -481,8 +472,7 @@ export const DrumKeyboardContainer: React.FC<DrumKeyboardContainerProps> = ({ on
                 e.currentTarget.style.backgroundColor = 'transparent';
 
                 const files = Array.from(e.dataTransfer.files).filter(
-                  (file) =>
-                    file.type.startsWith('audio/') || file.name.toLowerCase().endsWith('.wav')
+                  (file) => file.type.startsWith('audio/') || file.name.toLowerCase().endsWith('.wav')
                 );
 
                 // White key indices for both octaves (A, S, D, F, G, H, J)
@@ -575,8 +565,7 @@ export const DrumKeyboardContainer: React.FC<DrumKeyboardContainerProps> = ({ on
                 e.currentTarget.style.backgroundColor = 'transparent';
 
                 const files = Array.from(e.dataTransfer.files).filter(
-                  (file) =>
-                    file.type.startsWith('audio/') || file.name.toLowerCase().endsWith('.wav')
+                  (file) => file.type.startsWith('audio/') || file.name.toLowerCase().endsWith('.wav')
                 );
 
                 // Black key indices for both octaves (W, E, R, Y, U)

--- a/src/utils/audio.ts
+++ b/src/utils/audio.ts
@@ -1,10 +1,10 @@
 // Audio processing utilities migrated from legacy/lib/audio_tools.js
 // Enhanced with TypeScript types and improved functionality
 
-import { audioContextManager } from "./audioContext";
-import { AUDIO_CONSTANTS } from "./constants";
-import type { FilenameSeparator } from "./constants";
-import { audioBufferToWav } from "./wavExport";
+import { audioContextManager } from './audioContext';
+import { AUDIO_CONSTANTS } from './constants';
+import type { FilenameSeparator } from './constants';
+import { audioBufferToWav } from './wavExport';
 
 // Constants preserved from legacy for compatibility
 const HEADER_LENGTH = 44;
@@ -38,21 +38,14 @@ interface WavMetadata extends WavHeader, SmplChunk {
 // Enhanced WAV metadata parsing with SMPL chunk support
 export async function readWavMetadata(
   file: File,
-  mapping: "C3" | "C4" = "C3"
+  mapping: 'C3' | 'C4' = 'C3'
 ): Promise<WavMetadata> {
   try {
     const arrayBuffer = await file.arrayBuffer();
-    return await readWavMetadataFromArrayBuffer(
-      arrayBuffer,
-      file.name,
-      file.size,
-      mapping
-    );
+    return await readWavMetadataFromArrayBuffer(arrayBuffer, file.name, file.size, mapping);
   } catch (error) {
     throw new Error(
-      `Failed to read WAV metadata: ${
-        error instanceof Error ? error.message : "Unknown error"
-      }`
+      `Failed to read WAV metadata: ${error instanceof Error ? error.message : 'Unknown error'}`
     );
   }
 }
@@ -62,7 +55,7 @@ export async function readWavMetadataFromArrayBuffer(
   arrayBuffer: ArrayBuffer,
   filename: string,
   fileSize: number,
-  mapping: "C3" | "C4" = "C3"
+  mapping: 'C3' | 'C4' = 'C3'
 ): Promise<WavMetadata> {
   try {
     // Create separate copies for parsing and decoding to avoid detached buffer issues
@@ -82,13 +75,7 @@ export async function readWavMetadataFromArrayBuffer(
     const duration = audioBuffer.duration;
 
     // Parse SMPL chunk for loop points and MIDI note using the parse buffer
-    const smplData = parseSmplChunk(
-      dataView,
-      header.sampleRate,
-      duration,
-      filename,
-      mapping
-    );
+    const smplData = parseSmplChunk(dataView, header.sampleRate, duration, filename, mapping);
 
     return {
       format: header.format,
@@ -106,9 +93,7 @@ export async function readWavMetadataFromArrayBuffer(
     };
   } catch (error) {
     throw new Error(
-      `Failed to read WAV metadata: ${
-        error instanceof Error ? error.message : "Unknown error"
-      }`
+      `Failed to read WAV metadata: ${error instanceof Error ? error.message : 'Unknown error'}`
     );
   }
 }
@@ -116,19 +101,15 @@ export async function readWavMetadataFromArrayBuffer(
 // Parse WAV file header
 function parseWavHeader(dataView: DataView): WavHeader {
   // Check RIFF header
-  const riff = String.fromCharCode(
-    ...Array.from(new Uint8Array(dataView.buffer, 0, 4))
-  );
-  if (riff !== "RIFF") {
-    throw new Error("Invalid WAV file: missing RIFF header");
+  const riff = String.fromCharCode(...Array.from(new Uint8Array(dataView.buffer, 0, 4)));
+  if (riff !== 'RIFF') {
+    throw new Error('Invalid WAV file: missing RIFF header');
   }
 
   // Check WAVE format
-  const wave = String.fromCharCode(
-    ...Array.from(new Uint8Array(dataView.buffer, 8, 4))
-  );
-  if (wave !== "WAVE") {
-    throw new Error("Invalid WAV file: missing WAVE format");
+  const wave = String.fromCharCode(...Array.from(new Uint8Array(dataView.buffer, 8, 4)));
+  if (wave !== 'WAVE') {
+    throw new Error('Invalid WAV file: missing WAVE format');
   }
 
   // Find fmt chunk
@@ -137,14 +118,12 @@ function parseWavHeader(dataView: DataView): WavHeader {
   let dataOffset = -1;
 
   while (offset < dataView.byteLength - 8) {
-    const chunkId = String.fromCharCode(
-      ...Array.from(new Uint8Array(dataView.buffer, offset, 4))
-    );
+    const chunkId = String.fromCharCode(...Array.from(new Uint8Array(dataView.buffer, offset, 4)));
     const chunkSize = dataView.getUint32(offset + 4, true);
 
-    if (chunkId === "fmt ") {
+    if (chunkId === 'fmt ') {
       fmtOffset = offset + 8;
-    } else if (chunkId === "data") {
+    } else if (chunkId === 'data') {
       dataOffset = offset + 8;
       break;
     }
@@ -153,7 +132,7 @@ function parseWavHeader(dataView: DataView): WavHeader {
   }
 
   if (fmtOffset === -1) {
-    throw new Error("Invalid WAV file: missing fmt chunk");
+    throw new Error('Invalid WAV file: missing fmt chunk');
   }
 
   // Parse fmt chunk
@@ -164,17 +143,16 @@ function parseWavHeader(dataView: DataView): WavHeader {
 
   // Map audio format codes to readable names
   const formatNames: Record<number, string> = {
-    1: "PCM",
-    3: "IEEE Float",
-    6: "A-law",
-    7: "μ-law",
-    65534: "Extensible",
+    1: 'PCM',
+    3: 'IEEE Float',
+    6: 'A-law',
+    7: 'μ-law',
+    65534: 'Extensible',
   };
 
   const formatName = formatNames[audioFormat] || `Format ${audioFormat}`;
 
-  const dataLength =
-    dataOffset !== -1 ? dataView.getUint32(dataOffset - 4, true) : 0;
+  const dataLength = dataOffset !== -1 ? dataView.getUint32(dataOffset - 4, true) : 0;
 
   return {
     format: formatName,
@@ -191,7 +169,7 @@ function parseSmplChunk(
   sampleRate: number,
   duration: number,
   filename: string,
-  mapping: "C3" | "C4" = "C3"
+  mapping: 'C3' | 'C4' = 'C3'
 ): SmplChunk {
   let offset = 12;
 
@@ -211,7 +189,7 @@ function parseSmplChunk(
     );
     const chunkSize = dataView.getUint32(offset + 4, true);
 
-    if (chunkId === "smpl") {
+    if (chunkId === 'smpl') {
       // Parse SMPL chunk
       const smplOffset = offset + 8;
 
@@ -286,10 +264,7 @@ export async function normalizeAudioBuffer(
   audioBuffer: AudioBuffer,
   targetLevelDB: number = 0.0
 ): Promise<AudioBuffer> {
-  const normalizeGain = calculatePeakNormalizationGain(
-    audioBuffer,
-    targetLevelDB
-  );
+  const normalizeGain = calculatePeakNormalizationGain(audioBuffer, targetLevelDB);
 
   // Create a new audio buffer with the same properties
   const audioContext = await audioContextManager.getAudioContext();
@@ -448,8 +423,7 @@ export async function convertAudioFormat(
   const normalize = options.normalize || false;
   const normalizeLevel = options.normalizeLevel ?? 0.0; // Default to 0.0 dBFS (will be overridden by specific tool constants)
   const gain = options.gain || 0;
-  const shouldApplyLimiter =
-    options.applyLimiter !== undefined ? options.applyLimiter : false;
+  const shouldApplyLimiter = options.applyLimiter !== undefined ? options.applyLimiter : false;
 
   // Apply trim to loop end if enabled (do this first to get correct duration)
   let processedBuffer = audioBuffer;
@@ -480,10 +454,7 @@ export async function convertAudioFormat(
   // Apply normalization if enabled
   let normalizeGain = 1;
   if (normalize) {
-    normalizeGain = calculatePeakNormalizationGain(
-      processedBuffer,
-      normalizeLevel
-    );
+    normalizeGain = calculatePeakNormalizationGain(processedBuffer, normalizeLevel);
     gainValue *= normalizeGain;
   }
 
@@ -492,9 +463,7 @@ export async function convertAudioFormat(
   // Handle channel conversion
   if (targetChannels !== processedBuffer.numberOfChannels) {
     // Add channel splitter/merger for channel conversion
-    const splitter = offlineContext.createChannelSplitter(
-      processedBuffer.numberOfChannels
-    );
+    const splitter = offlineContext.createChannelSplitter(processedBuffer.numberOfChannels);
     const merger = offlineContext.createChannelMerger(targetChannels);
 
     source.connect(splitter);
@@ -512,10 +481,7 @@ export async function convertAudioFormat(
       gainNode.connect(merger, 0, 1);
     } else {
       // Direct channel mapping - create separate gain nodes for each channel
-      const numChannels = Math.min(
-        targetChannels,
-        processedBuffer.numberOfChannels
-      );
+      const numChannels = Math.min(targetChannels, processedBuffer.numberOfChannels);
       const gainNodes: GainNode[] = [];
 
       for (let i = 0; i < numChannels; i++) {
@@ -545,9 +511,7 @@ export async function convertAudioFormat(
     // Set limiter threshold based on normalization target
     // Add small headroom (0.1dB) to prevent limiting normalized audio
     // Ensure threshold is never positive to prevent clipping
-    const limiterThreshold = normalize
-      ? Math.min(normalizeLevel + 0.1, 0.0)
-      : 0.0;
+    const limiterThreshold = normalize ? Math.min(normalizeLevel + 0.1, 0.0) : 0.0;
     result = await applyLimiter(result, limiterThreshold);
   }
 
@@ -584,7 +548,7 @@ export async function calculatePatchSize(
 export function findNearestZeroCrossing(
   audioBuffer: AudioBuffer,
   framePosition: number,
-  direction: "forward" | "backward" | "both" = "both",
+  direction: 'forward' | 'backward' | 'both' = 'both',
   maxDistance: number = 1000,
   bounds?: { min?: number; max?: number }
 ): number {
@@ -598,19 +562,14 @@ export function findNearestZeroCrossing(
   let minAmplitude = Math.abs(channelData[framePosition]);
 
   const searchStart =
-    direction === "forward"
-      ? framePosition
-      : Math.max(0, framePosition - maxDistance);
+    direction === 'forward' ? framePosition : Math.max(0, framePosition - maxDistance);
   const searchEnd =
-    direction === "backward"
-      ? framePosition
-      : Math.min(length - 1, framePosition + maxDistance);
+    direction === 'backward' ? framePosition : Math.min(length - 1, framePosition + maxDistance);
 
   // Apply bounds if provided
   const boundedSearchStart =
     bounds?.min !== undefined ? Math.max(searchStart, bounds.min) : searchStart;
-  const boundedSearchEnd =
-    bounds?.max !== undefined ? Math.min(searchEnd, bounds.max) : searchEnd;
+  const boundedSearchEnd = bounds?.max !== undefined ? Math.min(searchEnd, bounds.max) : searchEnd;
 
   for (let i = boundedSearchStart; i <= boundedSearchEnd; i++) {
     const amplitude = Math.abs(channelData[i]);
@@ -643,8 +602,7 @@ export function applyZeroCrossingToMarkers(
   loopEnd?: number;
   adjustments: { marker: string; original: number; adjusted: number }[];
 } {
-  const adjustments: { marker: string; original: number; adjusted: number }[] =
-    [];
+  const adjustments: { marker: string; original: number; adjusted: number }[] = [];
 
   // Convert time-based positions to frame positions
   const inFrame = Math.floor(inPoint * audioBuffer.sampleRate);
@@ -654,12 +612,12 @@ export function applyZeroCrossingToMarkers(
   const adjustedInFrame = findNearestZeroCrossing(
     audioBuffer,
     inFrame,
-    "forward",
+    'forward',
     maxSearchDistance
   );
   if (adjustedInFrame !== inFrame) {
     adjustments.push({
-      marker: "inPoint",
+      marker: 'inPoint',
       original: inFrame,
       adjusted: adjustedInFrame,
     });
@@ -669,12 +627,12 @@ export function applyZeroCrossingToMarkers(
   const adjustedOutFrame = findNearestZeroCrossing(
     audioBuffer,
     outFrame,
-    "backward",
+    'backward',
     maxSearchDistance
   );
   if (adjustedOutFrame !== outFrame) {
     adjustments.push({
-      marker: "outPoint",
+      marker: 'outPoint',
       original: outFrame,
       adjusted: adjustedOutFrame,
     });
@@ -693,14 +651,14 @@ export function applyZeroCrossingToMarkers(
     adjustedLoopStart = findNearestZeroCrossing(
       audioBuffer,
       loopStartFrame,
-      "both",
+      'both',
       maxSearchDistance,
       { min: inFrame, max: outFrame }
     );
 
     if (adjustedLoopStart !== loopStartFrame) {
       adjustments.push({
-        marker: "loopStart",
+        marker: 'loopStart',
         original: loopStartFrame,
         adjusted: adjustedLoopStart,
       });
@@ -716,14 +674,14 @@ export function applyZeroCrossingToMarkers(
     adjustedLoopEnd = findNearestZeroCrossing(
       audioBuffer,
       loopEndFrame,
-      "both",
+      'both',
       maxSearchDistance,
       { min: inFrame, max: outFrame }
     );
 
     if (adjustedLoopEnd !== loopEndFrame) {
       adjustments.push({
-        marker: "loopEnd",
+        marker: 'loopEnd',
         original: loopEndFrame,
         adjusted: adjustedLoopEnd,
       });
@@ -735,13 +693,8 @@ export function applyZeroCrossingToMarkers(
     inPoint: adjustedInFrame / audioBuffer.sampleRate,
     outPoint: adjustedOutFrame / audioBuffer.sampleRate,
     loopStart:
-      adjustedLoopStart !== undefined
-        ? adjustedLoopStart / audioBuffer.sampleRate
-        : undefined,
-    loopEnd:
-      adjustedLoopEnd !== undefined
-        ? adjustedLoopEnd / audioBuffer.sampleRate
-        : undefined,
+      adjustedLoopStart !== undefined ? adjustedLoopStart / audioBuffer.sampleRate : undefined,
+    loopEnd: adjustedLoopEnd !== undefined ? adjustedLoopEnd / audioBuffer.sampleRate : undefined,
     adjustments,
   };
 
@@ -749,10 +702,7 @@ export function applyZeroCrossingToMarkers(
 }
 
 // Enhanced resample audio with better quality
-export async function resampleAudio(
-  file: File,
-  targetSampleRate: number
-): Promise<Blob> {
+export async function resampleAudio(file: File, targetSampleRate: number): Promise<Blob> {
   const audioContext = await audioContextManager.getAudioContext();
 
   try {
@@ -761,7 +711,7 @@ export async function resampleAudio(
 
     // Skip resampling if already at target rate
     if (audioBuffer.sampleRate === targetSampleRate) {
-      return new Blob([arrayBuffer], { type: "audio/wav" });
+      return new Blob([arrayBuffer], { type: 'audio/wav' });
     }
 
     const converted = await convertAudioFormat(audioBuffer, {
@@ -769,14 +719,14 @@ export async function resampleAudio(
     });
     return await audioBufferToWav(converted);
   } catch (error) {
-    console.error("Error during audio resampling:", error);
+    console.error('Error during audio resampling:', error);
     throw error;
   }
 }
 
 // Existing functions preserved for compatibility
 export function sanitizeName(name: string): string {
-  return name.replace(/[^a-zA-Z0-9 #\-().]+/g, "");
+  return name.replace(/[^a-zA-Z0-9 #\-().]+/g, '');
 }
 
 /**
@@ -798,11 +748,8 @@ export function getInvalidPresetNameChars(name: string): string[] {
   return invalidChars ? [...new Set(invalidChars)] : [];
 }
 
-export function parseFilename(
-  filename: string,
-  mapping: "C3" | "C4" = "C3"
-): [string, number] {
-  const nameWithoutExt = filename.replace(/\.[^/.]+$/, "");
+export function parseFilename(filename: string, mapping: 'C3' | 'C4' = 'C3'): [string, number] {
+  const nameWithoutExt = filename.replace(/\.[^/.]+$/, '');
 
   // Look for the first occurrence of either:
   // - A note name (C4, D#5, etc.)
@@ -811,9 +758,7 @@ export function parseFilename(
   // The regex captures everything before the first number/note pattern
   const match = nameWithoutExt.match(/^(.*?)[\s-]*([A-G](?:b|#)?\d|\d{1,3})/i);
   if (!match) {
-    throw new Error(
-      `Filename '${filename}' does not match the expected pattern.`
-    );
+    throw new Error(`Filename '${filename}' does not match the expected pattern.`);
   }
   const baseName = sanitizeName(match[1]);
   const noteOrNumber = match[2];
@@ -825,68 +770,48 @@ export function parseFilename(
 }
 
 export const NOTE_OFFSET = [33, 35, 24, 26, 28, 29, 31];
-export const NOTE_NAMES = [
-  "C",
-  "C#",
-  "D",
-  "D#",
-  "E",
-  "F",
-  "F#",
-  "G",
-  "G#",
-  "A",
-  "A#",
-  "B",
-];
+export const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
 
-export function midiNoteToString(
-  value: number,
-  mapping: "C3" | "C4" = "C3"
-): string {
-  if (value < 0 || value > 127) return "";
+export function midiNoteToString(value: number, mapping: 'C3' | 'C4' = 'C3'): string {
+  if (value < 0 || value > 127) return '';
   const noteNumber = value % 12;
   // C3=60: octave = Math.floor(value / 12) - 2
   // C4=60: octave = Math.floor(value / 12) - 1
-  const octave =
-    mapping === "C3" ? Math.floor(value / 12) - 2 : Math.floor(value / 12) - 1;
+  const octave = mapping === 'C3' ? Math.floor(value / 12) - 2 : Math.floor(value / 12) - 1;
   return `${NOTE_NAMES[noteNumber]}${octave}`;
 }
 
 const NOTE_NAME_TO_SEMITONE: Record<string, number> = {
   C: 0,
-  "C#": 1,
+  'C#': 1,
   Db: 1,
   D: 2,
-  "D#": 3,
+  'D#': 3,
   Eb: 3,
   E: 4,
   F: 5,
-  "F#": 6,
+  'F#': 6,
   Gb: 6,
   G: 7,
-  "G#": 8,
+  'G#': 8,
   Ab: 8,
   A: 9,
-  "A#": 10,
+  'A#': 10,
   Bb: 10,
   B: 11,
 };
 
-export function noteStringToMidiValue(
-  note: string,
-  mapping: "C3" | "C4" = "C3"
-): number {
+export function noteStringToMidiValue(note: string, mapping: 'C3' | 'C4' = 'C3'): number {
   const match = note.match(/^([A-Ga-g])([#b]?)(-?\d+)$/);
-  if (!match) throw new Error("Bad note format");
+  if (!match) throw new Error('Bad note format');
   const [, letter, accidental, octaveStr] = match;
-  const base = letter.toUpperCase() + (accidental || "");
+  const base = letter.toUpperCase() + (accidental || '');
   const semitone = NOTE_NAME_TO_SEMITONE[base];
-  if (semitone === undefined) throw new Error("Bad note");
+  if (semitone === undefined) throw new Error('Bad note');
   const octave = parseInt(octaveStr, 10);
   // C3=60: (octave + 2) * 12 + semitone
   // C4=60: (octave + 1) * 12 + semitone
-  return (mapping === "C3" ? (octave + 2) * 12 : (octave + 1) * 12) + semitone;
+  return (mapping === 'C3' ? (octave + 2) * 12 : (octave + 1) * 12) + semitone;
 }
 
 // Enhanced base template objects for OP-XY patches
@@ -898,17 +823,17 @@ export const baseMultisampleJson = {
   fx: {
     active: false,
     params: [0, 0, 0, 0, 0, 0, 0, 0],
-    type: "svf",
+    type: 'svf',
   },
   lfo: {
     active: false,
     params: [0, 0, 0, 0, 0, 0, 0, 0],
-    type: "element",
+    type: 'element',
   },
   octave: 0,
-  platform: "OP-XY",
+  platform: 'OP-XY',
   regions: [],
-  type: "multisampler",
+  type: 'multisampler',
   version: 4,
 };
 
@@ -919,23 +844,23 @@ export const baseDrumJson = {
     modulation: {
       aftertouch: { amount: 16383, target: 0 },
     },
-    playmode: "poly",
+    playmode: 'poly',
     transpose: 0,
-    "velocity.sensitivity": 4915, // ~15% of 32767
+    'velocity.sensitivity': 4915, // ~15% of 32767
     volume: 26214, // ~80% of 32767
     width: 0, // 0% stereo width
   },
-  platform: "OP-XY",
-  type: "drum",
+  platform: 'OP-XY',
+  type: 'drum',
   version: 4,
 };
 
 // Utility functions
 export function formatFileSize(bytes: number): string {
-  if (bytes === 0) return "0 mb";
-  if (bytes < 1024) return bytes + " b";
-  if (bytes < 1048576) return (bytes / 1024).toFixed(1) + " kb";
-  return (bytes / 1048576).toFixed(1) + " mb";
+  if (bytes === 0) return '0 mb';
+  if (bytes < 1024) return bytes + ' b';
+  if (bytes < 1048576) return (bytes / 1024).toFixed(1) + ' kb';
+  return (bytes / 1048576).toFixed(1) + ' mb';
 }
 
 export function isPatchSizeValid(sizeBytes: number): boolean {
@@ -946,9 +871,9 @@ export function getPatchSizeWarning(sizeBytes: number): string | null {
   const percentage = (sizeBytes / PATCH_SIZE_LIMIT) * 100;
 
   if (percentage >= 95) {
-    return "Preset size too large - reduce sample rate, bit depth, or convert to mono";
+    return 'Preset size too large - reduce sample rate, bit depth, or convert to mono';
   } else if (percentage >= 75) {
-    return "Approaching size limit - consider optimizing samples";
+    return 'Approaching size limit - consider optimizing samples';
   }
 
   return null;
@@ -968,52 +893,49 @@ export function getPatchSizeWarning(sizeBytes: number): string | null {
 export function generateFilename(
   presetName: string,
   separator: FilenameSeparator,
-  type: "drum" | "multisample",
+  type: 'drum' | 'multisample',
   index: number,
   _originalName: string,
-  mapping: "C3" | "C4" = "C3",
-  extension: string = "wav"
+  mapping: 'C3' | 'C4' = 'C3',
+  extension: string = 'wav'
 ): string {
   // Normalize separators in preset name and trim leading/trailing separators
   const normalizedPresetName = presetName
     .replace(/[ _-]+/g, separator)
-    .replace(/^[ _-]+|[ _-]+$/g, "");
+    .replace(/^[ _-]+|[ _-]+$/g, '');
 
   // Sanitize preset name - remove invalid characters but keep the chosen separator
-  const allowedChars = separator === " " ? "a-zA-Z0-9 " : "a-zA-Z0-9-";
-  const cleanPresetName = normalizedPresetName.replace(
-    new RegExp(`[^${allowedChars}]`, "g"),
-    ""
-  );
+  const allowedChars = separator === ' ' ? 'a-zA-Z0-9 ' : 'a-zA-Z0-9-';
+  const cleanPresetName = normalizedPresetName.replace(new RegExp(`[^${allowedChars}]`, 'g'), '');
 
-  if (type === "drum") {
+  if (type === 'drum') {
     // Short drum key labels by index (from DrumKeyboard.tsx)
     // Updated to match current drum key mappings
     const drumShortLabels = [
-      "KD1",
-      "KD2",
-      "SD1",
-      "SD2",
-      "RIM",
-      "CLP",
-      "TB",
-      "SH",
-      "CH",
-      "CL1",
-      "OH",
-      "CAB",
-      "LT1",
-      "RC",
-      "MT",
-      "CC",
-      "HT",
-      "COW",
-      "TRI",
-      "LT2",
-      "LC",
-      "WS",
-      "HC",
-      "GUI",
+      'KD1',
+      'KD2',
+      'SD1',
+      'SD2',
+      'RIM',
+      'CLP',
+      'TB',
+      'SH',
+      'CH',
+      'CL1',
+      'OH',
+      'CAB',
+      'LT1',
+      'RC',
+      'MT',
+      'CC',
+      'HT',
+      'COW',
+      'TRI',
+      'LT2',
+      'LC',
+      'WS',
+      'HC',
+      'GUI',
     ];
     const drumLabel = drumShortLabels[index] || `DRUM${index + 1}`;
 
@@ -1035,7 +957,7 @@ export function getEffectiveSampleRate(
 ): number {
   const selected = selectedRate.toString();
 
-  if (selected === "0") {
+  if (selected === '0') {
     // Keep original
     return originalSampleRate;
   }

--- a/src/utils/audio.ts
+++ b/src/utils/audio.ts
@@ -36,17 +36,12 @@ interface WavMetadata extends WavHeader, SmplChunk {
 }
 
 // Enhanced WAV metadata parsing with SMPL chunk support
-export async function readWavMetadata(
-  file: File,
-  mapping: 'C3' | 'C4' = 'C3'
-): Promise<WavMetadata> {
+export async function readWavMetadata(file: File, mapping: 'C3' | 'C4' = 'C3'): Promise<WavMetadata> {
   try {
     const arrayBuffer = await file.arrayBuffer();
     return await readWavMetadataFromArrayBuffer(arrayBuffer, file.name, file.size, mapping);
   } catch (error) {
-    throw new Error(
-      `Failed to read WAV metadata: ${error instanceof Error ? error.message : 'Unknown error'}`
-    );
+    throw new Error(`Failed to read WAV metadata: ${error instanceof Error ? error.message : 'Unknown error'}`);
   }
 }
 
@@ -92,9 +87,7 @@ export async function readWavMetadataFromArrayBuffer(
       fileSize,
     };
   } catch (error) {
-    throw new Error(
-      `Failed to read WAV metadata: ${error instanceof Error ? error.message : 'Unknown error'}`
-    );
+    throw new Error(`Failed to read WAV metadata: ${error instanceof Error ? error.message : 'Unknown error'}`);
   }
 }
 
@@ -293,10 +286,7 @@ export async function normalizeAudioBuffer(
  * @param targetLevelDB - Target level in dBFS (default: 0.0)
  * @returns The gain factor to apply, or 1.0 if no normalization needed
  */
-export function calculatePeakNormalizationGain(
-  audioBuffer: AudioBuffer,
-  targetLevelDB: number = 0.0
-): number {
+export function calculatePeakNormalizationGain(audioBuffer: AudioBuffer, targetLevelDB: number = 0.0): number {
   // Find maximum amplitude across all channels
   let maxAmplitude = 0;
   for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
@@ -322,10 +312,7 @@ export function calculatePeakNormalizationGain(
  * @param threshold - Threshold in dBFS (default: -0.1dBFS for safety)
  * @returns A configured DynamicsCompressor node
  */
-export function createLimiter(
-  audioContext: BaseAudioContext,
-  threshold: number = -0.1
-): DynamicsCompressorNode {
+export function createLimiter(audioContext: BaseAudioContext, threshold: number = -0.1): DynamicsCompressorNode {
   const limiter = audioContext.createDynamicsCompressor();
 
   // Professional limiter settings
@@ -344,10 +331,7 @@ export function createLimiter(
  * @param threshold - Threshold in dBFS (default: -0.1dBFS for safety)
  * @returns The limited audio buffer
  */
-export async function applyLimiter(
-  audioBuffer: AudioBuffer,
-  threshold: number = -0.1
-): Promise<AudioBuffer> {
+export async function applyLimiter(audioBuffer: AudioBuffer, threshold: number = -0.1): Promise<AudioBuffer> {
   // Create offline context for processing
   const offlineContext = audioContextManager.createOfflineContext(
     audioBuffer.numberOfChannels,
@@ -377,10 +361,7 @@ export async function applyLimiter(
  * @param loopEnd - The loop end position in samples
  * @returns The trimmed audio buffer
  */
-export async function cutAudioAtLoopEnd(
-  audioBuffer: AudioBuffer,
-  loopEnd: number
-): Promise<AudioBuffer> {
+export async function cutAudioAtLoopEnd(audioBuffer: AudioBuffer, loopEnd: number): Promise<AudioBuffer> {
   // Validate loop end position
   if (loopEnd <= 0 || loopEnd >= audioBuffer.length) {
     return audioBuffer;
@@ -395,11 +376,7 @@ export async function cutAudioAtLoopEnd(
 
   // Create a new audio buffer with the cut length
   const audioContext = await audioContextManager.getAudioContext();
-  const cutBuffer = audioContext.createBuffer(
-    audioBuffer.numberOfChannels,
-    cutPoint,
-    audioBuffer.sampleRate
-  );
+  const cutBuffer = audioContext.createBuffer(audioBuffer.numberOfChannels, cutPoint, audioBuffer.sampleRate);
 
   // Copy the audio data up to the cut point
   for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
@@ -561,14 +538,11 @@ export function findNearestZeroCrossing(
   let bestPosition = framePosition;
   let minAmplitude = Math.abs(channelData[framePosition]);
 
-  const searchStart =
-    direction === 'forward' ? framePosition : Math.max(0, framePosition - maxDistance);
-  const searchEnd =
-    direction === 'backward' ? framePosition : Math.min(length - 1, framePosition + maxDistance);
+  const searchStart = direction === 'forward' ? framePosition : Math.max(0, framePosition - maxDistance);
+  const searchEnd = direction === 'backward' ? framePosition : Math.min(length - 1, framePosition + maxDistance);
 
   // Apply bounds if provided
-  const boundedSearchStart =
-    bounds?.min !== undefined ? Math.max(searchStart, bounds.min) : searchStart;
+  const boundedSearchStart = bounds?.min !== undefined ? Math.max(searchStart, bounds.min) : searchStart;
   const boundedSearchEnd = bounds?.max !== undefined ? Math.min(searchEnd, bounds.max) : searchEnd;
 
   for (let i = boundedSearchStart; i <= boundedSearchEnd; i++) {
@@ -609,12 +583,7 @@ export function applyZeroCrossingToMarkers(
   const outFrame = Math.floor(outPoint * audioBuffer.sampleRate);
 
   // Apply zero-crossing detection to in point (search forward)
-  const adjustedInFrame = findNearestZeroCrossing(
-    audioBuffer,
-    inFrame,
-    'forward',
-    maxSearchDistance
-  );
+  const adjustedInFrame = findNearestZeroCrossing(audioBuffer, inFrame, 'forward', maxSearchDistance);
   if (adjustedInFrame !== inFrame) {
     adjustments.push({
       marker: 'inPoint',
@@ -624,12 +593,7 @@ export function applyZeroCrossingToMarkers(
   }
 
   // Apply zero-crossing detection to out point (search backward)
-  const adjustedOutFrame = findNearestZeroCrossing(
-    audioBuffer,
-    outFrame,
-    'backward',
-    maxSearchDistance
-  );
+  const adjustedOutFrame = findNearestZeroCrossing(audioBuffer, outFrame, 'backward', maxSearchDistance);
   if (adjustedOutFrame !== outFrame) {
     adjustments.push({
       marker: 'outPoint',
@@ -648,13 +612,10 @@ export function applyZeroCrossingToMarkers(
     const outFrame = Math.floor(outPoint * audioBuffer.sampleRate);
 
     // Find zero crossing within the in/out point bounds
-    adjustedLoopStart = findNearestZeroCrossing(
-      audioBuffer,
-      loopStartFrame,
-      'both',
-      maxSearchDistance,
-      { min: inFrame, max: outFrame }
-    );
+    adjustedLoopStart = findNearestZeroCrossing(audioBuffer, loopStartFrame, 'both', maxSearchDistance, {
+      min: inFrame,
+      max: outFrame,
+    });
 
     if (adjustedLoopStart !== loopStartFrame) {
       adjustments.push({
@@ -671,13 +632,10 @@ export function applyZeroCrossingToMarkers(
     const outFrame = Math.floor(outPoint * audioBuffer.sampleRate);
 
     // Find zero crossing within the in/out point bounds
-    adjustedLoopEnd = findNearestZeroCrossing(
-      audioBuffer,
-      loopEndFrame,
-      'both',
-      maxSearchDistance,
-      { min: inFrame, max: outFrame }
-    );
+    adjustedLoopEnd = findNearestZeroCrossing(audioBuffer, loopEndFrame, 'both', maxSearchDistance, {
+      min: inFrame,
+      max: outFrame,
+    });
 
     if (adjustedLoopEnd !== loopEndFrame) {
       adjustments.push({
@@ -692,8 +650,7 @@ export function applyZeroCrossingToMarkers(
   const result = {
     inPoint: adjustedInFrame / audioBuffer.sampleRate,
     outPoint: adjustedOutFrame / audioBuffer.sampleRate,
-    loopStart:
-      adjustedLoopStart !== undefined ? adjustedLoopStart / audioBuffer.sampleRate : undefined,
+    loopStart: adjustedLoopStart !== undefined ? adjustedLoopStart / audioBuffer.sampleRate : undefined,
     loopEnd: adjustedLoopEnd !== undefined ? adjustedLoopEnd / audioBuffer.sampleRate : undefined,
     adjustments,
   };
@@ -900,9 +857,7 @@ export function generateFilename(
   extension: string = 'wav'
 ): string {
   // Normalize separators in preset name and trim leading/trailing separators
-  const normalizedPresetName = presetName
-    .replace(/[ _-]+/g, separator)
-    .replace(/^[ _-]+|[ _-]+$/g, '');
+  const normalizedPresetName = presetName.replace(/[ _-]+/g, separator).replace(/^[ _-]+|[ _-]+$/g, '');
 
   // Sanitize preset name - remove invalid characters but keep the chosen separator
   const allowedChars = separator === ' ' ? 'a-zA-Z0-9 ' : 'a-zA-Z0-9-';
@@ -951,10 +906,7 @@ export function generateFilename(
  * Get the effective sample rate (NO upsampling)
  * Matches legacy behavior: "0"=keep original, "44100"=44.1kHz, "22050"=22kHz, "11025"=11kHz
  */
-export function getEffectiveSampleRate(
-  originalSampleRate: number,
-  selectedRate: string | number
-): number {
+export function getEffectiveSampleRate(originalSampleRate: number, selectedRate: string | number): number {
   const selected = selectedRate.toString();
 
   if (selected === '0') {


### PR DESCRIPTION
- I was getting errors trying to use samples directly bounced from Serum 2 

"Error loading drum sample: Error: Failed to read audio metadata: Failed to read audio metadata: Failed to read WAV metadata: Unsupported WAV format: only PCM is supported"

In my testing I could use these samples fine. Updating this code to allow those samples still yields drum racks usable on the OP-XY. 

- Adds "organize mode". many users like their drumkits laid out like so: kicks on white keys, snares on incidentals etc. I added "organize mode" that looks like this: 

<img width="1043" height="668" alt="Screenshot 2025-11-03 at 8 32 03 AM" src="https://github.com/user-attachments/assets/9524108c-2108-4751-8853-5067a4bb7e17" />

It makes it SO FAST to make 2 part drum kits in this way. 

Thanks for this tool! Totally just for your consideration, if you want to keep your tool as is I have no gripes about that. 
