### PR TITLE
feat: add organize mode and FP32 WAV support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "op-patchstudio",
   "private": true,
-  "version": "0.15.6",
+  "version": "0.16.0",
   "type": "module",
   "description": "Free & open source preset creator for OP synthesizers. Upload samples, edit waveforms, adjust settingsand generate patches instantly.",
   "repository": {

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -4,6 +4,17 @@ all notable changes to this project will be documented in this file.
 
 the format is based on [keep a changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.16.0] - 2026-02-04
+
+### added
+- drum tool organize mode for bulk loading samples by keyboard row (lower/upper)
+- support for IEEE Float (FP32) WAV files (e.g., samples from Serum 2)
+
+## [0.15.6] - 2026-02-03
+
+### fixed
+- resolve critical preset generation bugs (#101, #103)
+
 ## [0.15.5] - 2025-09-22
 
 ### fixed

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "OP-PatchStudio [unofficial]",
   "short_name": "OP-PatchStudio",
-  "version": "0.15.6",
+  "version": "0.16.0",
   "description": "free and open source preset creator for OP synthesizers. upload samples, edit waveforms, adjust settings and generate patches instantly.",
   "start_url": "/",
   "display": "standalone",

--- a/src/components/drum/DrumSampleTable.tsx
+++ b/src/components/drum/DrumSampleTable.tsx
@@ -9,12 +9,14 @@ import { WaveformZoomModal } from '../common/WaveformZoomModal';
 import { FileDetailsBadges } from '../common/FileDetailsBadges';
 import { DrumSampleSettingsModal } from './DrumSampleSettingsModal';
 import { IconButton } from '../common/IconButton';
+import { getOrganizeModeLabelFull } from './DrumKeyboard';
 
 
 interface DrumSampleTableProps {
   onFileUpload: (index: number, file: File) => void;
   onClearSample: (index: number) => void;
   onRecordSample?: (index: number) => void;
+  isOrganizeMode?: boolean;
 }
 
 // Full drum names from OP-XY documentation - all lowercase
@@ -39,9 +41,18 @@ const c = {
   actionHover: 'var(--color-interactive-dark)',
 };
 
+// Organized indices for organize mode: all lower row first, then all upper row
+const organizedIndices = [
+  // Lower row (14 samples)
+  0, 2, 4, 6, 7, 9, 11, 12, 14, 16, 18, 19, 21, 23,
+  // Upper row (10 samples)
+  1, 3, 5, 8, 10, 13, 15, 17, 20, 22
+];
 
+// Default indices (0-23)
+const defaultIndices = Array.from({ length: 24 }, (_, i) => i);
 
-export function DrumSampleTable({ onFileUpload, onClearSample, onRecordSample }: DrumSampleTableProps) {
+export function DrumSampleTable({ onFileUpload, onClearSample, onRecordSample, isOrganizeMode = false }: DrumSampleTableProps) {
   const { state, dispatch } = useAppContext();
   const { play } = useAudioPlayer();
   const fileInputRefs = useRef<(HTMLInputElement | null)[]>([]);
@@ -270,7 +281,7 @@ export function DrumSampleTable({ onFileUpload, onClearSample, onRecordSample }:
           flexDirection: 'column',
           gap: '0.75rem'
         }}>
-          {Array.from({ length: 24 }, (_, index) => {
+          {(isOrganizeMode ? organizedIndices : defaultIndices).map((index) => {
             const sample = state.drumSamples[index];
             const isLoaded = sample?.isLoaded;
             
@@ -321,7 +332,7 @@ export function DrumSampleTable({ onFileUpload, onClearSample, onRecordSample }:
                       alignItems: 'center',
                       gap: '0.5rem'
                     }}>
-                      {drumSampleNames[index]}
+                      {isOrganizeMode ? getOrganizeModeLabelFull(index) : drumSampleNames[index]}
                       {sample?.hasBeenEdited && (
                         <i 
                           className="fas fa-pencil-alt" 
@@ -509,7 +520,8 @@ export function DrumSampleTable({ onFileUpload, onClearSample, onRecordSample }:
         padding: 0,
         margin: 0
       }}>
-        {state.drumSamples.map((sample, index) => {
+        {(isOrganizeMode ? organizedIndices : defaultIndices).map((index) => {
+          const sample = state.drumSamples[index];
           const isLoaded = sample?.isLoaded;
           
           return (
@@ -581,8 +593,8 @@ export function DrumSampleTable({ onFileUpload, onClearSample, onRecordSample }:
                       title="drag to reorder"
                     ></i>
                   )}
-                  {index < 24 
-                    ? drumSampleNames[index] 
+                  {index < 24
+                    ? (isOrganizeMode ? getOrganizeModeLabelFull(index) : drumSampleNames[index])
                     : 'unassigned'
                   }
                   {sample?.hasBeenEdited && (

--- a/src/components/drum/DrumTool.tsx
+++ b/src/components/drum/DrumTool.tsx
@@ -34,6 +34,7 @@ export function DrumTool() {
     targetIndex: number | null;
   }>({ isOpen: false, targetIndex: null });
   const [bulkEditModal, setBulkEditModal] = useState(false);
+  const [isOrganizeMode, setIsOrganizeMode] = useState(false);
 
   // Detect mobile screen size
   useEffect(() => {
@@ -454,7 +455,11 @@ export function DrumTool() {
       <div style={{
         padding: isMobile ? '1rem 0.5rem' : '2rem 2rem',
       }}>
-        <DrumKeyboardContainer onFileUpload={handleFileUpload} />
+        <DrumKeyboardContainer
+          onFileUpload={handleFileUpload}
+          isOrganizeMode={isOrganizeMode}
+          setIsOrganizeMode={setIsOrganizeMode}
+        />
       </div>
 
       {/* Tabbed Content Area */}
@@ -501,6 +506,7 @@ export function DrumTool() {
               onFileUpload={handleFileUpload}
               onClearSample={handleClearSample}
               onRecordSample={handleOpenRecording}
+              isOrganizeMode={isOrganizeMode}
             />
             {/* Action Buttons Below Table - RESTORED */}
             <div style={{

--- a/src/utils/audio.ts
+++ b/src/utils/audio.ts
@@ -134,14 +134,21 @@ function parseWavHeader(dataView: DataView): WavHeader {
   const sampleRate = dataView.getUint32(fmtOffset + 4, true);
   const bitDepth = dataView.getUint16(fmtOffset + 14, true);
 
-  if (audioFormat !== 1) {
-    throw new Error('Unsupported WAV format: only PCM is supported');
-  }
+  // Map audio format codes to readable names
+  // WebAudioAPI's decodeAudioData handles conversion automatically
+  const formatNames: Record<number, string> = {
+    1: 'PCM',
+    3: 'IEEE Float',
+    6: 'A-law',
+    7: 'μ-law',
+    65534: 'Extensible',
+  };
+  const formatName = formatNames[audioFormat] || `Format ${audioFormat}`;
 
   const dataLength = dataOffset !== -1 ? dataView.getUint32(dataOffset - 4, true) : 0;
 
   return {
-    format: 'PCM',
+    format: formatName,
     sampleRate,
     bitDepth,
     channels,


### PR DESCRIPTION
## Summary
- Add organize mode for drum tool with bulk sample loading by keyboard row
- Add support for IEEE Float (FP32) WAV files

## Features

### Organize Mode
- Toggle button in drum keyboard header
- Drop zones for lower row (LO1-LO14) and upper row (UP1-UP10)
- Sample table reorders to group lower/upper rows when active
- Visual indicators on keyboard keys showing row assignment

### FP32 WAV Support
- Removes PCM-only restriction, now accepts IEEE Float, A-law, μ-law, Extensible formats
- Enables Serum 2 and other FP32 exports to work directly

## Credits
Based on PR #98 by @WillCMcC, rebased onto current main and improved with:
- Monochrome UI styling to match existing design
- Accessibility improvements (aria-labels, roles)
- Full word labels in sample table ("lower 1", "upper 1", etc.)
- Row grouping in sample table when organize mode is active

## Test plan
- [ ] Toggle organize mode on/off - keyboard labels switch between drum names and LO/UP labels
- [ ] Drop files on lower/upper drop zones - samples load to correct slots
- [ ] Sample table shows grouped rows in organize mode, original order otherwise
- [ ] Load a 32-bit float WAV file (e.g., from Serum 2) - should work without error

🤖 Generated with [Claude Code](https://claude.ai/code)