### PR TITLE
feat: support dragging samples from Splice

### DIFF
--- a/src/components/common/FileDropZone.tsx
+++ b/src/components/common/FileDropZone.tsx
@@ -1,6 +1,7 @@
 import React, { useRef } from 'react';
 import { Button } from '@carbon/react';
 import type { DragEvent, ChangeEvent } from 'react';
+import { extractDroppedAudioFiles } from '../../utils/fileDrop';
 
 interface FileDropZoneProps {
   onFilesSelected: (files: File[]) => void;
@@ -28,23 +29,13 @@ export function FileDropZone({
     e.stopPropagation();
   };
 
-  const handleDrop = (e: DragEvent) => {
+  const handleDrop = async (e: DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
     
     if (disabled) return;
     
-    const files = Array.from(e.dataTransfer.files);
-    const audioFiles = files.filter(file => 
-      file.type.startsWith('audio/') || 
-      file.name.toLowerCase().endsWith('.wav') ||
-      file.name.toLowerCase().endsWith('.aif') ||
-      file.name.toLowerCase().endsWith('.aiff') ||
-      file.name.toLowerCase().endsWith('.mp3') ||
-      file.name.toLowerCase().endsWith('.m4a') ||
-      file.name.toLowerCase().endsWith('.ogg') ||
-      file.name.toLowerCase().endsWith('.flac')
-    );
+    const audioFiles = await extractDroppedAudioFiles(e.dataTransfer);
     
     if (audioFiles.length > 0) {
       onFilesSelected(audioFiles);
@@ -128,4 +119,4 @@ export function FileDropZone({
       </div>
     </>
   );
-} 
+}

--- a/src/components/drum/DrumKeyboard.tsx
+++ b/src/components/drum/DrumKeyboard.tsx
@@ -5,6 +5,7 @@ import { useWebMidi } from '../../hooks/useWebMidi';
 import type { MidiEvent } from '../../utils/midi';
 import type { WebMidiState, WebMidiHookReturn } from '../../hooks/useWebMidi';
 import { UI_CONSTANTS } from '../../utils/constants';
+import { extractDroppedAudioFiles } from '../../utils/fileDrop';
 
 
 // Drum key mapping for two octaves (matching legacy)
@@ -668,7 +669,7 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
             e.currentTarget.style.boxShadow = isActive ? '0 4px 12px rgba(0, 0, 0, 0.18)' : '0 2px 6px rgba(0, 0, 0, 0.1)';
             e.currentTarget.style.borderColor = !isActive ? 'var(--color-key-inactive-border)' : 'var(--color-black)';
           }}
-          onDrop={(e) => {
+          onDrop={async (e) => {
             e.preventDefault();
             e.stopPropagation();
             
@@ -678,10 +679,7 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
             e.currentTarget.style.boxShadow = isActive ? '0 4px 12px rgba(0, 0, 0, 0.18)' : '0 2px 6px rgba(0, 0, 0, 0.1)';
             e.currentTarget.style.borderColor = !isActive ? 'var(--color-key-inactive-border)' : 'var(--color-black)';
             
-            const files = Array.from(e.dataTransfer.files);
-            const audioFile = files.find(file => 
-              file.type.startsWith('audio/') || file.name.toLowerCase().endsWith('.wav')
-            );
+            const [audioFile] = await extractDroppedAudioFiles(e.dataTransfer);
             
             if (audioFile && mapping && onFileUpload) {
               onFileUpload(mapping.idx, audioFile);
@@ -1102,4 +1100,4 @@ export function DrumKeyboard({ onFileUpload, selectedMidiChannel, midiState: ext
       )}
     </div>
   );
-} 
+}

--- a/src/components/drum/DrumKeyboardContainer.tsx
+++ b/src/components/drum/DrumKeyboardContainer.tsx
@@ -6,6 +6,7 @@ import { MidiDeviceSelector } from '../common/MidiDeviceSelector';
 import { cookieUtils, COOKIE_KEYS } from '../../utils/cookies';
 import { useWebMidi } from '../../hooks/useWebMidi';
 import type { MidiEvent } from '../../utils/midi';
+import { extractDroppedAudioFiles } from '../../utils/fileDrop';
 
 interface DrumKeyboardContainerProps {
   onFileUpload?: (index: number, file: File) => void;
@@ -442,15 +443,13 @@ export const DrumKeyboardContainer: React.FC<DrumKeyboardContainerProps> = ({ on
                 e.currentTarget.style.borderColor = 'var(--color-border-medium)';
                 e.currentTarget.style.backgroundColor = 'transparent';
               }}
-              onDrop={(e) => {
+              onDrop={async (e) => {
                 e.preventDefault();
                 e.stopPropagation();
                 e.currentTarget.style.borderColor = 'var(--color-border-medium)';
                 e.currentTarget.style.backgroundColor = 'transparent';
 
-                const files = Array.from(e.dataTransfer.files).filter(
-                  (file) => file.type.startsWith('audio/') || file.name.toLowerCase().endsWith('.wav')
-                );
+                const files = await extractDroppedAudioFiles(e.dataTransfer);
 
                 // White key indices for both octaves (A, S, D, F, G, H, J)
                 const whiteKeyIndices = [
@@ -522,15 +521,13 @@ export const DrumKeyboardContainer: React.FC<DrumKeyboardContainerProps> = ({ on
                 e.currentTarget.style.borderColor = 'var(--color-border-medium)';
                 e.currentTarget.style.backgroundColor = 'transparent';
               }}
-              onDrop={(e) => {
+              onDrop={async (e) => {
                 e.preventDefault();
                 e.stopPropagation();
                 e.currentTarget.style.borderColor = 'var(--color-border-medium)';
                 e.currentTarget.style.backgroundColor = 'transparent';
 
-                const files = Array.from(e.dataTransfer.files).filter(
-                  (file) => file.type.startsWith('audio/') || file.name.toLowerCase().endsWith('.wav')
-                );
+                const files = await extractDroppedAudioFiles(e.dataTransfer);
 
                 // Black key indices for both octaves (W, E, R, Y, U)
                 const blackKeyIndices = [
@@ -590,4 +587,4 @@ export const DrumKeyboardContainer: React.FC<DrumKeyboardContainerProps> = ({ on
       </div>
     </>
   );
-}; 
+};

--- a/src/components/drum/DrumSampleTable.tsx
+++ b/src/components/drum/DrumSampleTable.tsx
@@ -10,7 +10,7 @@ import { FileDetailsBadges } from '../common/FileDetailsBadges';
 import { DrumSampleSettingsModal } from './DrumSampleSettingsModal';
 import { IconButton } from '../common/IconButton';
 import { getOrganizeModeLabelFull } from './DrumKeyboard';
-import { extractDroppedAudioFiles } from '../../utils/fileDrop';
+import { extractDroppedAudioFiles, getDropEffect } from '../../utils/fileDrop';
 
 
 interface DrumSampleTableProps {
@@ -140,7 +140,7 @@ export function DrumSampleTable({ onFileUpload, onClearSample, onRecordSample, i
 
   const handleSampleDragOver = (e: React.DragEvent, index: number) => {
     e.preventDefault();
-    e.dataTransfer.dropEffect = 'move';
+    e.dataTransfer.dropEffect = getDropEffect(e.dataTransfer);
     setHoveredIndex(index);
   };
 

--- a/src/components/drum/DrumSampleTable.tsx
+++ b/src/components/drum/DrumSampleTable.tsx
@@ -10,6 +10,7 @@ import { FileDetailsBadges } from '../common/FileDetailsBadges';
 import { DrumSampleSettingsModal } from './DrumSampleSettingsModal';
 import { IconButton } from '../common/IconButton';
 import { getOrganizeModeLabelFull } from './DrumKeyboard';
+import { extractDroppedAudioFiles } from '../../utils/fileDrop';
 
 
 interface DrumSampleTableProps {
@@ -117,14 +118,11 @@ export function DrumSampleTable({ onFileUpload, onClearSample, onRecordSample, i
     e.stopPropagation();
   };
 
-  const handleDrop = (e: React.DragEvent, index: number) => {
+  const handleDrop = async (e: React.DragEvent, index: number) => {
     e.preventDefault();
     e.stopPropagation();
     
-    const files = Array.from(e.dataTransfer.files);
-    const audioFile = files.find(file => 
-      file.type.startsWith('audio/') || file.name.toLowerCase().endsWith('.wav')
-    );
+    const [audioFile] = await extractDroppedAudioFiles(e.dataTransfer);
     
     if (audioFile) {
       handleFileSelect(index, audioFile);
@@ -150,11 +148,11 @@ export function DrumSampleTable({ onFileUpload, onClearSample, onRecordSample, i
     setHoveredIndex(null);
   };
 
-  const handleSampleDrop = (e: React.DragEvent, targetIndex: number) => {
+  const handleSampleDrop = async (e: React.DragEvent, targetIndex: number) => {
     e.preventDefault();
     
     // Check if this is a file drop (external files)
-    const files = Array.from(e.dataTransfer.files).filter(file => file.type.startsWith('audio/'));
+    const files = await extractDroppedAudioFiles(e.dataTransfer);
     if (files.length) {
       files.forEach((file, i) => handleFileSelect(targetIndex + i, file));
     }
@@ -781,4 +779,4 @@ export function DrumSampleTable({ onFileUpload, onClearSample, onRecordSample, i
       />
     </div>
   );
-} 
+}

--- a/src/components/multisample/MultisampleSampleTable.tsx
+++ b/src/components/multisample/MultisampleSampleTable.tsx
@@ -7,7 +7,7 @@ import { WaveformZoomModal } from '../common/WaveformZoomModal';
 import { useAudioPlayer } from '../../hooks/useAudioPlayer';
 
 import { midiNoteToString, noteStringToMidiValue } from '../../utils/audio';
-import { extractDroppedAudioFiles, hasDroppedFiles, isAudioFile } from '../../utils/fileDrop';
+import { extractDroppedAudioFiles, getDropEffect, hasDroppedFiles, isAudioFile } from '../../utils/fileDrop';
 
 
 interface MultisampleSampleTableProps {
@@ -244,7 +244,7 @@ export function MultisampleSampleTable({
 
   const handleDragOver = (e: React.DragEvent, index: number) => {
     e.preventDefault();
-    e.dataTransfer.dropEffect = 'move';
+    e.dataTransfer.dropEffect = getDropEffect(e.dataTransfer);
     setHoveredIndex(index);
   };
 

--- a/src/components/multisample/MultisampleSampleTable.tsx
+++ b/src/components/multisample/MultisampleSampleTable.tsx
@@ -7,6 +7,7 @@ import { WaveformZoomModal } from '../common/WaveformZoomModal';
 import { useAudioPlayer } from '../../hooks/useAudioPlayer';
 
 import { midiNoteToString, noteStringToMidiValue } from '../../utils/audio';
+import { extractDroppedAudioFiles, hasDroppedFiles, isAudioFile } from '../../utils/fileDrop';
 
 
 interface MultisampleSampleTableProps {
@@ -101,7 +102,7 @@ export function MultisampleSampleTable({
   const handleTableDragOver = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    if (e.dataTransfer.types.includes('Files')) {
+    if (hasDroppedFiles(e.dataTransfer)) {
       setIsDragOver(true);
     }
   };
@@ -119,38 +120,7 @@ export function MultisampleSampleTable({
     e.stopPropagation();
     setIsDragOver(false);
     
-    const files: File[] = [];
-    
-    // Use the .items property for robust folder and file handling
-    if (e.dataTransfer.items && e.dataTransfer.items.length > 0) {
-      const items = Array.from(e.dataTransfer.items);
-      
-      // Process all dropped items in parallel
-      const processingPromises = items.map(item => {
-        const entry = item.webkitGetAsEntry();
-        if (entry) {
-          return processEntry(entry, files);
-        }
-        return Promise.resolve();
-      });
-      
-      await Promise.all(processingPromises);
-      
-    } else if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
-      // Fallback for browsers that don't support .items
-      files.push(...Array.from(e.dataTransfer.files));
-    }
-    
-    const audioFiles = files.filter(file => 
-      file.type.startsWith('audio/') || 
-      file.name.toLowerCase().endsWith('.wav') ||
-      file.name.toLowerCase().endsWith('.aif') ||
-      file.name.toLowerCase().endsWith('.aiff') ||
-      file.name.toLowerCase().endsWith('.mp3') ||
-      file.name.toLowerCase().endsWith('.m4a') ||
-      file.name.toLowerCase().endsWith('.ogg') ||
-      file.name.toLowerCase().endsWith('.flac')
-    );
+    const audioFiles = await extractDroppedAudioFiles(e.dataTransfer);
     
     const remainingSlots = 24 - state.multisampleFiles.length;
     const filesToProcess = audioFiles.slice(0, remainingSlots);
@@ -171,63 +141,6 @@ export function MultisampleSampleTable({
       }
       
       onFilesSelected(filesToProcess);
-    } else if (files.length > 0) {
-      // No audio files found in dropped items - can provide user feedback if desired
-    } else {
-      // No files found in drop event
-    }
-  };
-
-  const processEntry = async (entry: any, files: File[]): Promise<void> => {
-    try {
-      if (entry.isFile) {
-        const file = await new Promise<File>((resolve, reject) => {
-          entry.file((file: File) => {
-            if (file) {
-              resolve(file);
-            } else {
-              reject(new Error('Failed to get file from entry'));
-            }
-          });
-        });
-        files.push(file);
-      } else if (entry.isDirectory) {
-        const reader = entry.createReader();
-        
-        // Read all entries from the directory
-        const readEntries = (): Promise<any[]> => {
-          return new Promise((resolve, reject) => {
-            reader.readEntries((entries: any[]) => {
-              if (entries && entries.length > 0) {
-                resolve(entries);
-              } else {
-                resolve([]);
-              }
-            }, (error: any) => {
-              console.error('Error reading directory entries:', error);
-              reject(error);
-            });
-          });
-        };
-        
-        // Read all entries recursively (handle large directories)
-        let allEntries: any[] = [];
-        let hasMore = true;
-        
-        while (hasMore) {
-          const entries = await readEntries();
-          if (entries.length === 0) {
-            hasMore = false;
-          } else {
-            allEntries = allEntries.concat(entries);
-          }
-        }
-        
-        // Process all entries in parallel for better performance
-        await Promise.all(allEntries.map(childEntry => processEntry(childEntry, files)));
-      }
-    } catch (error) {
-      console.error('Error processing entry:', entry?.name, error);
     }
   };
 
@@ -244,7 +157,7 @@ export function MultisampleSampleTable({
   const handleBrowseFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || []);
     if (files.length > 0) {
-      const audioFiles = await extractAudioFiles(files);
+      const audioFiles = files.filter(isAudioFile);
       const remainingSlots = 24 - state.multisampleFiles.length;
       const filesToProcess = audioFiles.slice(0, remainingSlots);
       
@@ -269,25 +182,6 @@ export function MultisampleSampleTable({
       }
     }
     e.target.value = '';
-  };
-
-  const extractAudioFiles = async (files: File[]): Promise<File[]> => {
-    const audioFiles: File[] = [];
-    
-    for (const file of files) {
-      if (file.type.startsWith('audio/') || 
-          file.name.toLowerCase().endsWith('.wav') ||
-          file.name.toLowerCase().endsWith('.aif') ||
-          file.name.toLowerCase().endsWith('.aiff') ||
-          file.name.toLowerCase().endsWith('.mp3') ||
-          file.name.toLowerCase().endsWith('.m4a') ||
-          file.name.toLowerCase().endsWith('.ogg') ||
-          file.name.toLowerCase().endsWith('.flac')) {
-        audioFiles.push(file);
-      }
-    }
-    
-    return audioFiles;
   };
 
   const handleEmptyAreaClick = () => {
@@ -441,21 +335,11 @@ export function MultisampleSampleTable({
     e.stopPropagation();
   };
 
-  const handleRowDrop = (e: React.DragEvent, index: number) => {
+  const handleRowDrop = async (e: React.DragEvent, index: number) => {
     e.preventDefault();
     e.stopPropagation();
     
-    const files = Array.from(e.dataTransfer.files);
-    const audioFile = files.find(file => 
-      file.type.startsWith('audio/') || 
-      file.name.toLowerCase().endsWith('.wav') ||
-      file.name.toLowerCase().endsWith('.aif') ||
-      file.name.toLowerCase().endsWith('.aiff') ||
-      file.name.toLowerCase().endsWith('.mp3') ||
-      file.name.toLowerCase().endsWith('.m4a') ||
-      file.name.toLowerCase().endsWith('.ogg') ||
-      file.name.toLowerCase().endsWith('.flac')
-    );
+    const [audioFile] = await extractDroppedAudioFiles(e.dataTransfer);
     
     if (audioFile) {
       handleFileInputChange(index, { target: { files: [audioFile] } } as any);

--- a/src/components/multisample/VirtualMidiKeyboard.tsx
+++ b/src/components/multisample/VirtualMidiKeyboard.tsx
@@ -5,6 +5,7 @@ import { MidiDeviceSelector } from '../common/MidiDeviceSelector';
 import type { MidiEvent } from '../../utils/midi';
 import { useAppContext } from '../../context/AppContext';
 import { UI_CONSTANTS } from '../../utils/constants';
+import { extractDroppedAudioFiles, hasDroppedFiles } from '../../utils/fileDrop';
 
 interface VirtualMidiKeyboardProps {
   assignedNotes?: number[]; // MIDI note numbers that have samples assigned
@@ -470,7 +471,7 @@ export function VirtualMidiKeyboard({
   const handleKeyDragOver = useCallback((e: React.DragEvent, midiNote: number) => {
     e.preventDefault();
     e.stopPropagation();
-    if (e.dataTransfer.types.includes('Files')) {
+    if (hasDroppedFiles(e.dataTransfer)) {
       setDragOverKey(midiNote);
     }
   }, []);
@@ -481,14 +482,13 @@ export function VirtualMidiKeyboard({
     setDragOverKey(null);
   }, []);
 
-  const handleKeyDrop = useCallback((e: React.DragEvent, midiNote: number) => {
+  const handleKeyDrop = useCallback(async (e: React.DragEvent, midiNote: number) => {
     e.preventDefault();
     e.stopPropagation();
     setDragOverKey(null);
     
-    const files = Array.from(e.dataTransfer.files);
-    const wavFiles = files.filter(file => 
-      file.type === 'audio/wav' || file.name.toLowerCase().endsWith('.wav')
+    const wavFiles = (await extractDroppedAudioFiles(e.dataTransfer)).filter(file =>
+      file.name.toLowerCase().endsWith('.wav') || file.type === 'audio/wav'
     );
     
     if (wavFiles.length > 0) {
@@ -1281,4 +1281,4 @@ export function VirtualMidiKeyboard({
       </div>
     </>
   );
-} 
+}

--- a/src/test/utils/fileDrop.test.ts
+++ b/src/test/utils/fileDrop.test.ts
@@ -1,16 +1,19 @@
 import { describe, expect, it, vi } from 'vitest';
-import { extractDroppedAudioFiles, isAudioFile } from '../../utils/fileDrop';
+import { extractDroppedAudioFiles, getDropEffect, isAudioFile } from '../../utils/fileDrop';
 
 function createDataTransfer({
   files = [],
   items = [],
+  types = [],
 }: {
   files?: File[];
   items?: Partial<DataTransferItem>[];
+  types?: string[];
 }): DataTransfer {
   return {
     files,
     items,
+    types,
   } as unknown as DataTransfer;
 }
 
@@ -27,6 +30,19 @@ describe('fileDrop', () => {
     });
 
     await expect(extractDroppedAudioFiles(dataTransfer)).resolves.toEqual([sample]);
+  });
+
+  it('uses a copy drop effect for Splice file drags', () => {
+    const dataTransfer = createDataTransfer({
+      items: [{ kind: 'file', type: 'audio/wav' }],
+      types: ['Files'],
+    });
+
+    expect(getDropEffect(dataTransfer)).toBe('copy');
+  });
+
+  it('keeps the move drop effect for internal sample drags', () => {
+    expect(getDropEffect(createDataTransfer({}))).toBe('move');
   });
 
   it('falls back to files supplied by Finder', async () => {

--- a/src/test/utils/fileDrop.test.ts
+++ b/src/test/utils/fileDrop.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+import { extractDroppedAudioFiles, isAudioFile } from '../../utils/fileDrop';
+
+function createDataTransfer({
+  files = [],
+  items = [],
+}: {
+  files?: File[];
+  items?: Partial<DataTransferItem>[];
+}): DataTransfer {
+  return {
+    files,
+    items,
+  } as unknown as DataTransfer;
+}
+
+describe('fileDrop', () => {
+  it('extracts a Splice-style file item when dataTransfer.files is empty', async () => {
+    const sample = new File(['audio'], 'splice-sample.wav', { type: '' });
+    const dataTransfer = createDataTransfer({
+      items: [{
+        kind: 'file',
+        type: '',
+        getAsFile: vi.fn(() => sample),
+        webkitGetAsEntry: vi.fn(() => null),
+      }],
+    });
+
+    await expect(extractDroppedAudioFiles(dataTransfer)).resolves.toEqual([sample]);
+  });
+
+  it('falls back to files supplied by Finder', async () => {
+    const sample = new File(['audio'], 'finder-sample.aif', { type: 'audio/aiff' });
+    const dataTransfer = createDataTransfer({ files: [sample] });
+
+    await expect(extractDroppedAudioFiles(dataTransfer)).resolves.toEqual([sample]);
+  });
+
+  it('keeps recursively extracting audio files from dropped folders', async () => {
+    const sample = new File(['audio'], 'folder-sample.wav', { type: 'audio/wav' });
+    const fileEntry = {
+      isFile: true,
+      isDirectory: false,
+      file: (success: FileCallback) => success(sample),
+    } as FileSystemFileEntry;
+    const directoryEntry = {
+      isFile: false,
+      isDirectory: true,
+      createReader: () => {
+        let hasRead = false;
+        return {
+          readEntries: (success: FileSystemEntriesCallback) => {
+            const entries = hasRead ? [] : [fileEntry];
+            hasRead = true;
+            success(entries);
+          },
+        } as FileSystemDirectoryReader;
+      },
+    } as FileSystemDirectoryEntry;
+    const dataTransfer = createDataTransfer({
+      items: [{
+        kind: 'file',
+        webkitGetAsEntry: vi.fn(() => directoryEntry),
+      }],
+    });
+
+    await expect(extractDroppedAudioFiles(dataTransfer)).resolves.toEqual([sample]);
+  });
+
+  it('recognizes supported extensions when the source omits the MIME type', () => {
+    expect(isAudioFile(new File(['audio'], 'sample.WAV', { type: '' }))).toBe(true);
+    expect(isAudioFile(new File(['text'], 'notes.txt', { type: '' }))).toBe(false);
+  });
+});

--- a/src/utils/fileDrop.ts
+++ b/src/utils/fileDrop.ts
@@ -10,6 +10,10 @@ export function hasDroppedFiles(dataTransfer: DataTransfer): boolean {
     Array.from(dataTransfer.types).includes('Files');
 }
 
+export function getDropEffect(dataTransfer: DataTransfer): 'copy' | 'move' {
+  return hasDroppedFiles(dataTransfer) ? 'copy' : 'move';
+}
+
 function readFileEntry(entry: FileSystemFileEntry): Promise<File[]> {
   return new Promise((resolve, reject) => {
     entry.file(file => resolve([file]), reject);

--- a/src/utils/fileDrop.ts
+++ b/src/utils/fileDrop.ts
@@ -1,0 +1,76 @@
+const AUDIO_EXTENSIONS = ['.wav', '.aif', '.aiff', '.mp3', '.m4a', '.ogg', '.flac'];
+
+export function isAudioFile(file: File): boolean {
+  const name = file.name.toLowerCase();
+  return file.type.startsWith('audio/') || AUDIO_EXTENSIONS.some(extension => name.endsWith(extension));
+}
+
+export function hasDroppedFiles(dataTransfer: DataTransfer): boolean {
+  return Array.from(dataTransfer.items).some(item => item.kind === 'file') ||
+    Array.from(dataTransfer.types).includes('Files');
+}
+
+function readFileEntry(entry: FileSystemFileEntry): Promise<File[]> {
+  return new Promise((resolve, reject) => {
+    entry.file(file => resolve([file]), reject);
+  });
+}
+
+function readDirectoryEntries(reader: FileSystemDirectoryReader): Promise<FileSystemEntry[]> {
+  return new Promise((resolve, reject) => {
+    const entries: FileSystemEntry[] = [];
+
+    const readBatch = () => {
+      reader.readEntries(batch => {
+        if (batch.length === 0) {
+          resolve(entries);
+          return;
+        }
+
+        entries.push(...batch);
+        readBatch();
+      }, reject);
+    };
+
+    readBatch();
+  });
+}
+
+async function readEntry(entry: FileSystemEntry): Promise<File[]> {
+  if (entry.isFile) {
+    return readFileEntry(entry as FileSystemFileEntry);
+  }
+
+  if (entry.isDirectory) {
+    const children = await readDirectoryEntries((entry as FileSystemDirectoryEntry).createReader());
+    return (await Promise.all(children.map(readEntry))).flat();
+  }
+
+  return [];
+}
+
+export async function extractDroppedFiles(dataTransfer: DataTransfer): Promise<File[]> {
+  // Drag data becomes protected after the drop callback returns, so capture all
+  // synchronously available handles before waiting for directory traversal.
+  const fallbackFiles = Array.from(dataTransfer.files);
+  const itemResults = await Promise.all(
+    Array.from(dataTransfer.items)
+      .filter(item => item.kind === 'file')
+      .map(item => {
+        const entry = item.webkitGetAsEntry?.();
+        if (entry) {
+          return readEntry(entry).catch(() => []);
+        }
+
+        const file = item.getAsFile();
+        return Promise.resolve(file ? [file] : []);
+      }),
+  );
+  const itemFiles = itemResults.flat();
+
+  return itemFiles.length > 0 ? itemFiles : fallbackFiles;
+}
+
+export async function extractDroppedAudioFiles(dataTransfer: DataTransfer): Promise<File[]> {
+  return (await extractDroppedFiles(dataTransfer)).filter(isAudioFile);
+}


### PR DESCRIPTION
I really like the op.patch studio, but found importing splice samples a bit unpleasant, since I had to drag them from finder and could not directly drag from splice. 

<img width="800" height="502" alt="CleanShot 2026-07-17 at 10 46 38" src="https://github.com/user-attachments/assets/c8b139bf-3d36-4d03-92d0-d90a8390f11a" />

## Code Change Summary
- extract file-kind `DataTransferItem`s used by desktop apps such as Splice
- centralized audio-file filtering and folder traversal across drum and multisample drop targets into dedicated functions
- preserve Finder drag-and-drop fallback and support files with missing MIME metadata
- add regression coverage for Splice-style, Finder, and folder payloads

## Notes
- Repository-wide `npm run lint` still reports pre-existing lint errors outside this change.

> 💡 this PR was created with AI assistance. I used `opencode` with `GPT 5.6 Sol (high reasoning)`